### PR TITLE
feat: Implement pipx installation support

### DIFF
--- a/servers/jira-helper/pyproject.toml
+++ b/servers/jira-helper/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira-helper"
@@ -20,12 +20,13 @@ dependencies = [
     "sse-starlette>=1.6.5",
     "rich>=13.0.0",
     "typer>=0.9.0",
-    "jira>=3.5.2",
-    "PyYAML>=6.0.1"
+    "atlassian-python-api",
+    "PyYAML>=6.0.1",
+    "mcp"
 ]
 
 [project.scripts]
-jira-helper = "src.main:app"
+jira-helper = "main:app"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src"]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/servers/jira-helper/pyproject.toml
+++ b/servers/jira-helper/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "jira-helper"
+version = "0.1.0"
+description = "A Jira helper MCP server"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [
+    {name = "MCP Server Team", email = "example@example.com"},
+]
+dependencies = [
+    "python-dotenv>=1.0.0",
+    "fastapi>=0.100.0",
+    "uvicorn>=0.22.0",
+    "pydantic>=2.0.0",
+    "requests>=2.31.0",
+    "sse-starlette>=1.6.5",
+    "rich>=13.0.0",
+    "typer>=0.9.0",
+    "jira>=3.5.2",
+    "PyYAML>=6.0.1"
+]
+
+[project.scripts]
+jira-helper = "src.main:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/utils/mcp_manager/PIPX_IMPLEMENTATION_CHECKLIST.md
+++ b/utils/mcp_manager/PIPX_IMPLEMENTATION_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Pipx Installation and Configuration Checklist
+
+This document outlines the development plan for adding `pipx` installation support to `mcp-manager`. The goal is to provide an alternative, more robust installation method for local MCP servers, treating them as first-class Python CLI applications.
+
+## Phase 1: Core `pipx` Integration
+
+-   [ ] **Extend `LocalServer` Model:**
+    -   Add a new field `installation_type` to the `LocalServer` model in `server.py`. This will be an `Enum` with values like `VENV` (current method) and `PIPX`.
+    -   Add an optional `package_name` field to store the PyPI package name if it differs from the server name.
+    -   Add an optional `executable_name` field to store the name of the pipx-installed executable.
+
+-   [ ] **Create `install` Command Extension:**
+    -   Modify the `install` command in `mcp_manager/commands/install.py`.
+    -   Add a `--pipx` flag to trigger installation via `pipx`.
+    -   When `--pipx` is used, the command should:
+        -   Run `pipx install .` from the server's source directory.
+        -   Verify the installation was successful by checking the output and `pipx list`.
+        -   Store the installation type as `PIPX` in the server registry.
+        -   Identify and store the executable path provided by `pipx`.
+
+-   [ ] **Update `configure` Command:**
+    -   Modify `configure_vscode_cline` in `mcp_manager/commands/configure.py`.
+    -   Add a condition to check the `installation_type` of the `LocalServer`.
+    -   If the type is `PIPX`:
+        -   The `command` in `cline_mcp_settings.json` should be the path to the pipx-installed executable (e.g., `~/.local/bin/jira-helper`).
+        -   The `args` should be `["stdio"]`.
+        -   The `options` (like `cwd` and `PYTHONPATH`) will no longer be necessary, as `pipx` handles the environment.
+    -   If the type is `VENV`, the behavior should remain as it is now (pointing to the venv's Python).
+
+## Phase 2: Server Packaging and Distribution
+
+-   [ ] **Standardize `pyproject.toml` for Servers:**
+    -   Ensure each local server (like `jira-helper`) has a `pyproject.toml` file that correctly defines its entry points.
+    -   The `[project.scripts]` section should define the executable name. For example: `jira-helper = "jira_helper.main:app"`.
+
+-   [ ] **Refactor Server Entry Points:**
+    -   Ensure each server's `main.py` is structured to work as a CLI application, preferably using a library like `typer` or `click`, which is already a dependency of `mcp-manager`. This will standardize argument parsing (`stdio`, `sse`, etc.).
+
+-   [ ] **Build and Test Distribution:**
+    -   Add a script or command to build a distributable wheel (`.whl`) for each server.
+    -   Test installing the built wheel using `pipx install <path_to_wheel>`.
+
+## Phase 3: Uninstallation and Management
+
+-   [ ] **Extend `uninstall` Command:**
+    -   Modify the `uninstall` command in `mcp_manager/commands/uninstall.py`.
+    -   If the server's `installation_type` is `PIPX`, the command should run `pipx uninstall <package_name>`.
+    -   It should also remove the server entry from the registry.
+
+-   [ ] **Documentation:**
+    -   Update `README.md` to explain the new `--pipx` installation option.
+    -   Document the required `pyproject.toml` structure for any new servers to be compatible with `pipx` installation.

--- a/utils/mcp_manager/src/mcp_manager/cli.py
+++ b/utils/mcp_manager/src/mcp_manager/cli.py
@@ -68,6 +68,9 @@ def install_local(
     force: bool = typer.Option(
         False, "--force", "-f", help="Force installation, overwriting existing server"
     ),
+    pipx: bool = typer.Option(
+        False, "--pipx", help="Install using pipx instead of a virtual environment"
+    ),
 ):
     """Install a local MCP server from a directory."""
     from mcp_manager.commands.install import install_local_server
@@ -78,7 +81,7 @@ def install_local(
         raise typer.Exit(1)
     
     try:
-        install_local_server(name, source, port, force)
+        install_local_server(name, source, port, force, pipx)
         console.print(f"[bold green]Success:[/bold green] MCP server '{name}' installed.")
     except Exception as e:
         console.print(f"[bold red]Error:[/bold red] {e}")

--- a/utils/mcp_manager/src/mcp_manager/commands/configure.py
+++ b/utils/mcp_manager/src/mcp_manager/commands/configure.py
@@ -23,6 +23,7 @@ from mcp_manager.server import (
     RemoteServer,
     ServerRegistry,
     ServerType,
+    InstallationType,
     get_registry_path,
     get_bin_dir,
     get_vscode_cline_settings_path,
@@ -78,33 +79,51 @@ def configure_vscode_cline(backup: bool = True) -> None:
     # Add/update servers
     for name, server in registry.servers.items():
         if isinstance(server, LocalServer):
-            # Determine the Python executable path in the server's virtual environment
-            if sys.platform == "win32":
-                python_executable = server.venv_dir / "Scripts" / "python.exe"
-            else:
-                python_executable = server.venv_dir / "bin" / "python"
+            if server.installation_type == InstallationType.PIPX:
+                if not server.executable_name:
+                    console.print(f"[bold red]Error:[/bold red] Executable name not set for pipx-installed server '{name}'")
+                    continue
+                
+                executable_path = shutil.which(server.executable_name)
+                if not executable_path:
+                    console.print(f"[bold red]Error:[/bold red] Executable '{server.executable_name}' not found in PATH for server '{name}'")
+                    continue
 
-            if not python_executable.exists():
-                console.print(f"[bold red]Error:[/bold red] Python executable not found for server '{name}' at '{python_executable}'")
-                continue
+                settings["mcpServers"][name] = {
+                    "command": str(executable_path),
+                    "args": ["stdio"],
+                    "disabled": server.disabled,
+                    "autoApprove": server.auto_approve,
+                }
+            else:  # Default to VENV
+                if not server.venv_dir:
+                    console.print(f"[bold red]Error:[/bold red] venv_dir not set for venv-installed server '{name}'")
+                    continue
 
-            # Determine the main script path
-            main_script_path = server.source_dir / "main.py"
-            if not main_script_path.exists():
-                console.print(f"[bold red]Error:[/bold red] main.py not found for server '{name}' at '{main_script_path}'")
-                continue
+                if sys.platform == "win32":
+                    python_executable = server.venv_dir / "Scripts" / "python.exe"
+                else:
+                    python_executable = server.venv_dir / "bin" / "python"
 
-            # Add/update the server configuration for direct Python execution
-            settings["mcpServers"][name] = {
-                "command": str(python_executable),
-                "args": [str(main_script_path), "stdio"],  # Pass 'stdio' as a default argument
-                "options": {
-                    "cwd": str(server.source_dir),
-                    "env": {"PYTHONPATH": str(server.source_dir)}
-                },
-                "disabled": server.disabled,
-                "autoApprove": server.auto_approve,
-            }
+                if not python_executable.exists():
+                    console.print(f"[bold red]Error:[/bold red] Python executable not found for server '{name}' at '{python_executable}'")
+                    continue
+
+                main_script_path = server.source_dir / "main.py"
+                if not main_script_path.exists():
+                    console.print(f"[bold red]Error:[/bold red] main.py not found for server '{name}' at '{main_script_path}'")
+                    continue
+
+                settings["mcpServers"][name] = {
+                    "command": str(python_executable),
+                    "args": [str(main_script_path), "stdio"],
+                    "options": {
+                        "cwd": str(server.source_dir),
+                        "env": {"PYTHONPATH": str(server.source_dir)},
+                    },
+                    "disabled": server.disabled,
+                    "autoApprove": server.auto_approve,
+                }
         elif isinstance(server, RemoteServer):
             # Add/update the server
             settings["mcpServers"][name] = {

--- a/utils/mcp_manager/src/mcp_manager/commands/configure.py
+++ b/utils/mcp_manager/src/mcp_manager/commands/configure.py
@@ -84,9 +84,13 @@ def configure_vscode_cline(backup: bool = True) -> None:
                     console.print(f"[bold red]Error:[/bold red] Executable name not set for pipx-installed server '{name}'")
                     continue
                 
-                executable_path = shutil.which(server.executable_name)
-                if not executable_path:
-                    console.print(f"[bold red]Error:[/bold red] Executable '{server.executable_name}' not found in PATH for server '{name}'")
+                if not server.venv_dir:
+                    console.print(f"[bold red]Error:[/bold red] venv_dir not set for pipx-installed server '{name}'")
+                    continue
+
+                executable_path = server.venv_dir / "bin" / server.executable_name
+                if not executable_path.exists():
+                    console.print(f"[bold red]Error:[/bold red] Executable '{executable_path}' not found for server '{name}'")
                     continue
 
                 settings["mcpServers"][name] = {

--- a/utils/mcp_manager/src/mcp_manager/server.py
+++ b/utils/mcp_manager/src/mcp_manager/server.py
@@ -24,6 +24,13 @@ class ServerType(str, Enum):
     REMOTE_SSE = "remote_sse"
 
 
+class InstallationType(str, Enum):
+    """Enum for the installation type of a local server."""
+    
+    VENV = "venv"
+    PIPX = "pipx"
+
+
 class ServerBase(BaseModel):
     """Base model for all types of MCP servers."""
     
@@ -38,9 +45,17 @@ class ServerBase(BaseModel):
 class LocalServer(ServerBase):
     """Model for locally installed MCP servers."""
     
+    installation_type: InstallationType = InstallationType.VENV
     source_dir: Path
-    venv_dir: Path
+    
+    # Fields for 'venv' installation type
+    venv_dir: Optional[Path] = None
     requirements_file: Optional[Path] = None
+    
+    # Fields for 'pipx' installation type
+    package_name: Optional[str] = None
+    executable_name: Optional[str] = None
+    
     port: Optional[int] = None  # Only used for LOCAL_SSE
     
     @validator('server_type')


### PR DESCRIPTION
This PR implements the pipx installation feature for mcp-manager.

Key changes:
- Extends LocalServer model with InstallationType enum and pipx fields.
- Adds --pipx flag to the install command to handle pipx installations.
- Updates configure command to support both venv and pipx installation types.
- Adds pyproject.toml to jira-helper server.
- Refactors jira-helper main.py to be a typer CLI application.