### PR TITLE
Add loadbearing-youtube MCP server

### DIFF
--- a/.claude/skills/install-mcp-server/SKILL.md
+++ b/.claude/skills/install-mcp-server/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: install-mcp-server
+description: >-
+  Install a BaseMcpServer MCP server (loadbearing-youtube, worldcontext,
+  jira-helper, mcpservercreator) via mcp-manager and wire it into Claude
+  Desktop / Cline. Use when the user wants to install, add, set up, or enable
+  one of these MCP servers — for example the loadbearing-youtube tool that
+  extracts a YouTube transcript and exposes its load-bearing components.
+---
+
+# Install a BaseMcpServer MCP server
+
+This skill installs one of the MCP servers in the `dawsonlp/BaseMcpServer`
+monorepo into the user's `mcp-manager` registry and (optionally) wires it into
+Claude Desktop / Cline. It works whether or not the repo is already cloned.
+
+## Server catalog
+
+| Server | What it gives the agent | Needs config? |
+|---|---|---|
+| `loadbearing-youtube` | Extract a YouTube transcript and expose its **load-bearing components** (`analyze_video`, `get_video_transcript`, `list_analysis_providers`). | No — defaults to local Ollama. Optional OpenAI/Anthropic keys. |
+| `worldcontext` | Current date/time, market, news, dev-tool versions. | Optional API keys for market/news. |
+| `jira-helper` | Jira + Confluence integration. | **Yes** — Jira URL + credentials. |
+| `mcpservercreator` | Scaffold new MCP servers from a code snippet. | No. |
+
+## Fast path (recommended)
+
+Run the bundled installer. It ensures `uv` + `mcp-manager` exist, locates the
+server source (or shallow-clones the public repo), installs it, and syncs.
+
+```bash
+# from anywhere:
+bash scripts/install_mcp_server.sh loadbearing-youtube
+```
+
+Useful flags:
+- `--no-sync` — register the server but don't touch editor settings yet.
+- `--force` — reinstall an already-installed server.
+- `--transport sse` — install as an HTTP/SSE server instead of stdio.
+- `--source DIR` — install from a specific local checkout.
+
+> **Ask before syncing to editors.** `mcp-manager config sync` edits the user's
+> Claude Desktop / Cline settings files (persistent app configuration). If the
+> user only asked to "install" the server, run with `--no-sync` first, then
+> confirm before syncing.
+
+## Manual path (if you want to run the steps yourself)
+
+```bash
+# 1. One-time: uv + mcp-manager
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv tool install "git+https://github.com/dawsonlp/BaseMcpServer.git#subdirectory=utils/mcp_manager"
+uv tool update-shell
+
+# 2. Get the repo (skip if already cloned; then cd into it)
+git clone --depth 1 https://github.com/dawsonlp/BaseMcpServer.git
+cd BaseMcpServer
+
+# 3. Install the server (isolated uv env under ~/.config/mcp-manager/servers/<name>/)
+mcp-manager install local loadbearing-youtube --source ./servers/loadbearing-youtube
+
+# 4. (If the server needs credentials) edit its config, then sync into editors
+$EDITOR ~/.config/mcp-manager/servers/loadbearing-youtube/config.yaml   # not needed for loadbearing-youtube
+mcp-manager config sync
+```
+
+## Configuration notes
+
+- Install copies `config.yaml.example` → `~/.config/mcp-manager/servers/<name>/config.yaml`.
+- `loadbearing-youtube` works out of the box against a local **Ollama** daemon
+  (no API key). To use a cloud model instead, set `analysis.provider` /
+  `analysis.model` in that config, and export `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
+- `jira-helper` requires real Jira credentials before it will work — edit its
+  config before syncing.
+
+## Verify
+
+```bash
+mcp-manager info list                    # server should appear as installed
+mcp-manager info show loadbearing-youtube # details + config path
+```
+
+After a `config sync`, restart Claude Desktop / reload the VS Code window so the
+client picks up the new server. The agent should then see tools like
+`analyze_video`.
+
+## Uninstall / redo
+
+```bash
+mcp-manager remove loadbearing-youtube   # reversible; then config sync again
+```
+
+## Troubleshooting
+
+- **`mcp-manager: command not found`** after install → run `uv tool update-shell`
+  and open a new shell.
+- **`uv is required but was not found`** → install uv (step 1) and re-run.
+- **`Server '<name>' already exists`** → add `--force` to reinstall.
+- **loadbearing-youtube analysis errors about Ollama** → ensure `ollama serve`
+  is running, or switch the provider to OpenAI/Anthropic in its config.
+- The server installs from a pinned git dependency, so the machine needs network
+  access to GitHub the first time.

--- a/.claude/skills/install-mcp-server/scripts/install_mcp_server.sh
+++ b/.claude/skills/install-mcp-server/scripts/install_mcp_server.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Install a BaseMcpServer MCP server via mcp-manager, from anywhere.
+#
+# Usage:
+#   install_mcp_server.sh <server-name> [--source DIR] [--transport stdio|sse]
+#                         [--force] [--no-sync]
+#
+# Behaviour:
+#   1. Ensures `uv` and `mcp-manager` are available (installs mcp-manager if not).
+#   2. Locates the server source: --source, else ./servers/<name> if run inside
+#      the repo, else a shallow clone of the public BaseMcpServer repo in a cache.
+#   3. Runs `mcp-manager install local <name> --source <dir>`.
+#   4. Unless --no-sync, runs `mcp-manager config sync` to wire it into Cline /
+#      Claude Desktop.
+#
+# Idempotent: pass --force to reinstall an already-installed server.
+set -euo pipefail
+
+REPO_URL="https://github.com/dawsonlp/BaseMcpServer.git"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/basemcpserver"
+
+SERVER=""
+SOURCE=""
+TRANSPORT="stdio"
+FORCE=""
+SYNC="yes"
+
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo ">> $*" >&2; }
+
+# --- args ------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="${2:-}"; shift 2 ;;
+    --transport) TRANSPORT="${2:-}"; shift 2 ;;
+    --force) FORCE="--force"; shift ;;
+    --no-sync) SYNC="no"; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) die "unknown option: $1" ;;
+    *) [ -z "$SERVER" ] && SERVER="$1" || die "unexpected arg: $1"; shift ;;
+  esac
+done
+[ -n "$SERVER" ] || die "server name is required (e.g. loadbearing-youtube)"
+
+# --- prerequisites ---------------------------------------------------------
+command -v uv >/dev/null 2>&1 || die \
+  "uv not found. Install it: curl -LsSf https://astral.sh/uv/install.sh | sh"
+
+if ! command -v mcp-manager >/dev/null 2>&1; then
+  info "mcp-manager not found; installing it as a uv tool..."
+  uv tool install "git+${REPO_URL}#subdirectory=utils/mcp_manager"
+  uv tool update-shell || true
+  command -v mcp-manager >/dev/null 2>&1 || die \
+    "mcp-manager still not on PATH. Open a new shell (uv tool update-shell) and retry."
+fi
+
+# --- locate the server source ----------------------------------------------
+if [ -z "$SOURCE" ]; then
+  if [ -f "./servers/$SERVER/pyproject.toml" ]; then
+    SOURCE="./servers/$SERVER"
+  else
+    info "Not inside the repo; using a shallow clone at $CACHE_DIR"
+    if [ -d "$CACHE_DIR/.git" ]; then
+      git -C "$CACHE_DIR" pull --ff-only --quiet || info "clone pull skipped"
+    else
+      mkdir -p "$(dirname "$CACHE_DIR")"
+      git clone --depth 1 "$REPO_URL" "$CACHE_DIR"
+    fi
+    SOURCE="$CACHE_DIR/servers/$SERVER"
+  fi
+fi
+[ -f "$SOURCE/pyproject.toml" ] || die "no server source at: $SOURCE"
+
+# --- install ---------------------------------------------------------------
+info "Installing '$SERVER' from $SOURCE (transport: $TRANSPORT)"
+mcp-manager install local "$SERVER" --source "$SOURCE" --transport "$TRANSPORT" $FORCE
+
+# --- wire into editors -----------------------------------------------------
+if [ "$SYNC" = "yes" ]; then
+  info "Syncing into detected AI platforms (Cline / Claude Desktop)..."
+  mcp-manager config sync
+else
+  info "Skipping editor sync (--no-sync). Run 'mcp-manager config sync' when ready."
+fi
+
+CONFIG="$HOME/.config/mcp-manager/servers/$SERVER/config.yaml"
+info "Done. Server '$SERVER' registered."
+[ -f "$CONFIG" ] && info "Config (edit for credentials if the server needs them): $CONFIG"
+info "Inspect with: mcp-manager info show $SERVER"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ BaseMcpServer/
 │   ├── jira-helper/           # Jira + Confluence integration server (multi-instance)
 │   ├── worldcontext/          # Current-context tools (date/time, market, news, dev-tool versions)
 │   ├── mcpservercreator/      # Generator that scaffolds new MCP servers from a code snippet
+│   ├── loadbearing-youtube/   # Extract a YouTube transcript + expose its load-bearing components
 │   └── template/              # Starter scaffold to fork when building a new server
 ├── docs/
 │   ├── adr/                   # Architecture Decision Records
@@ -30,9 +31,10 @@ uv tool install "git+https://github.com/dawsonlp/BaseMcpServer.git#subdirectory=
 uv tool update-shell
 
 # 2. Install whichever servers you want
-mcp-manager install local jira-helper      --source ./servers/jira-helper
-mcp-manager install local worldcontext     --source ./servers/worldcontext
-mcp-manager install local mcpservercreator --source ./servers/mcpservercreator
+mcp-manager install local jira-helper        --source ./servers/jira-helper
+mcp-manager install local worldcontext       --source ./servers/worldcontext
+mcp-manager install local mcpservercreator   --source ./servers/mcpservercreator
+mcp-manager install local loadbearing-youtube --source ./servers/loadbearing-youtube
 
 # 3. Edit the per-server config files (where credentials go) — see each server's README
 $EDITOR ~/.config/mcp-manager/servers/jira-helper/config.yaml

--- a/servers/loadbearing-youtube/.gitignore
+++ b/servers/loadbearing-youtube/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+config.yaml
+.env
+.pytest_cache/
+uv.lock

--- a/servers/loadbearing-youtube/README.md
+++ b/servers/loadbearing-youtube/README.md
@@ -1,0 +1,59 @@
+# loadbearing_youtube MCP Server
+
+Extract a YouTube transcript from a URL and expose its **load-bearing
+components** — the claims, decisions, tradeoffs, comparison verdicts, and
+recommendation the video's conclusion actually rests on. Not a generic summary.
+
+This server is a thin adapter over the
+[`loadbearing_youtube`](../../../loadbearing_youtube) package (the first in the
+`loadbearing_*` family); all pipeline, provider, and analysis logic lives there.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `analyze_video` | Fetch transcript + expose load-bearing components (structured data + markdown). |
+| `get_video_transcript` | Fetch the full transcript only (no LLM), with optional `[mm:ss]` timestamps. |
+| `list_analysis_providers` | List LLM providers, which are configured, and their models. |
+
+## Configuration
+
+Copy `config.yaml.example` and set defaults. Ollama is the local, no-API-key
+default; OpenAI/Anthropic work if their keys are set in the environment.
+
+```yaml
+analysis:
+  provider: "ollama"   # ollama | openai | anthropic
+  model: ""            # blank = provider default
+  languages: "en"
+```
+
+Any tool argument (`provider`, `model`, `languages`) overrides the config; if
+both are blank the underlying package falls back to its own `LOADBEARING_*`
+environment defaults.
+
+## Run
+
+```bash
+# stdio (for MCP clients)
+loadbearing-youtube-mcp stdio
+# or SSE / HTTP
+loadbearing-youtube-mcp sse
+```
+
+The server's console script is `loadbearing-youtube-mcp` (the plain
+`loadbearing-youtube` name belongs to the package's own CLI).
+
+## Tests
+
+```bash
+uv run pytest
+```
+
+## Note on the dependency (cleanup item)
+
+`loadbearing_youtube` is currently an **unpublished local sibling repo**, so
+`pyproject.toml` resolves it via `[tool.uv.sources]` as an editable path
+(`../../../loadbearing_youtube`). When that package is published (PyPI or a git
+tag), delete the `[tool.uv.sources]` block and let the
+`loadbearing-youtube>=0.1.0` dependency resolve normally.

--- a/servers/loadbearing-youtube/config.yaml.example
+++ b/servers/loadbearing-youtube/config.yaml.example
@@ -1,0 +1,14 @@
+# loadbearing_youtube MCP Server Configuration
+
+server:
+  name: "loadbearing-youtube"
+  host: "localhost"
+  port: 7502
+
+# Defaults for the analysis. Any tool argument overrides these; if left blank
+# here, the loadbearing_youtube package falls back to its own LOADBEARING_* env
+# defaults. Ollama is local and needs no API key.
+analysis:
+  provider: "ollama"   # ollama | openai | anthropic
+  model: ""            # blank = provider default (e.g. llama3.2 for ollama)
+  languages: "en"

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube>=0.1.0",
+    "loadbearing-youtube @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -37,13 +37,6 @@ where = ["src"]
 
 [tool.setuptools.package-dir]
 "" = "src"
-
-# The loadbearing_youtube package is currently a local, unpublished sibling repo.
-# uv resolves it from this path (editable) for local dev / verification.
-# CLEANUP: once dawsonlp/loadbearing_youtube is published (PyPI or a git tag),
-# drop this and let the `loadbearing-youtube>=0.1.0` dependency resolve normally.
-[tool.uv.sources]
-loadbearing-youtube = { path = "../../../loadbearing_youtube", editable = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "loadbearing-youtube-mcp-server"
+version = "0.1.0"
+description = "loadbearing_youtube MCP Server - extract a YouTube transcript and expose its load-bearing components"
+authors = [
+    {name = "Larry Dawson"}
+]
+readme = "README.md"
+requires-python = ">=3.11"
+
+dependencies = [
+    "mcp>=1.27.0",
+    "mcp-commons>=2.2.2",
+    "PyYAML>=6.0.3",
+    "loadbearing-youtube>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+# NB: script name is *-mcp to avoid colliding with the loadbearing_youtube
+# package's own `loadbearing-youtube` CLI when both are installed together.
+[project.scripts]
+loadbearing-youtube-mcp = "main:main"
+
+[tool.setuptools]
+py-modules = ["main", "config", "tool_config"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+# The loadbearing_youtube package is currently a local, unpublished sibling repo.
+# uv resolves it from this path (editable) for local dev / verification.
+# CLEANUP: once dawsonlp/loadbearing_youtube is published (PyPI or a git tag),
+# drop this and let the `loadbearing-youtube>=0.1.0` dependency resolve normally.
+[tool.uv.sources]
+loadbearing-youtube = { path = "../../../loadbearing_youtube", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/servers/loadbearing-youtube/src/config.py
+++ b/servers/loadbearing-youtube/src/config.py
@@ -1,0 +1,9 @@
+"""Configuration management for the loadbearing_youtube MCP Server."""
+
+from mcp_commons import create_config, load_dotenv_file
+
+load_dotenv_file()
+
+# mcp-commons looks under ~/.config/mcp-manager/servers/loadbearing-youtube/config.yaml
+# first, then ~/.config/loadbearing-youtube/config.yaml, then ./config.yaml.
+config = create_config(server_name="loadbearing-youtube", env_prefix="LOADBEARING_YOUTUBE")

--- a/servers/loadbearing-youtube/src/main.py
+++ b/servers/loadbearing-youtube/src/main.py
@@ -1,0 +1,28 @@
+"""Main entry point for the loadbearing_youtube MCP Server."""
+
+from mcp_commons import create_mcp_app, run_cli
+
+from config import config
+from tool_config import get_tools_config
+
+
+def main() -> None:
+    run_cli(
+        server_name=config.get("server", "name", default="loadbearing-youtube"),
+        tools_config=get_tools_config(),
+        description="- Expose the load-bearing components of a YouTube video",
+        host=config.get("server", "host", default="localhost"),
+        port=config.get("server", "port", default=7502),
+    )
+
+
+def create_app():
+    """ASGI factory for running under an external server (uvicorn, etc.)."""
+    return create_mcp_app(
+        server_name=config.get("server", "name", default="loadbearing-youtube"),
+        tools_config=get_tools_config(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/servers/loadbearing-youtube/src/tool_config.py
+++ b/servers/loadbearing-youtube/src/tool_config.py
@@ -1,0 +1,143 @@
+"""
+Tool Configuration for the loadbearing_youtube MCP Server.
+
+Thin adapter: the real work lives in the `loadbearing_youtube` package
+(pipeline, providers, analysis). Each function here returns a plain,
+JSON-serialisable dict; mcp-commons handles the MCP protocol details.
+"""
+
+import logging
+from typing import Any, Dict
+
+from loadbearing_youtube import analyze, get_transcript
+from loadbearing_youtube.providers import discover
+from loadbearing_youtube.render import render_markdown, render_transcript
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve(provider: str, model: str, languages: str) -> tuple:
+    """Precedence for each setting: explicit tool arg > server config.yaml >
+    the loadbearing_youtube env defaults (handled downstream)."""
+    prov = provider or config.get("analysis", "provider", default="") or None
+    mdl = model or config.get("analysis", "model", default="") or None
+    langs = languages or config.get("analysis", "languages", default="en") or "en"
+    lang_list = [x.strip() for x in langs.split(",") if x.strip()] or ["en"]
+    return prov, mdl, lang_list
+
+
+def get_video_transcript(url: str, languages: str = "", timestamps: bool = True) -> Dict[str, Any]:
+    """Fetch the full transcript of a YouTube video (no LLM involved).
+
+    Args:
+        url: YouTube video URL or 11-character video id.
+        languages: Comma-separated language preference (e.g. "en,es"). Blank = "en".
+        timestamps: Include [mm:ss] markers in the transcript text.
+    """
+    if not url or not isinstance(url, str):
+        return {"error": "url must be a non-empty string", "success": False}
+
+    _, _, lang_list = _resolve("", "", languages)
+    try:
+        t = get_transcript(url, lang_list)
+    except Exception as e:
+        logger.warning("transcript fetch failed for %s: %s", url, e)
+        return {"error": str(e), "success": False}
+
+    return {
+        "success": True,
+        "video_id": t.video_id,
+        "url": t.url,
+        "title": t.title,
+        "author": t.author,
+        "language": t.language,
+        "is_generated": t.is_generated,
+        "duration_seconds": round(t.duration, 1),
+        "char_count": t.char_count,
+        "segment_count": len(t.segments),
+        "transcript": render_transcript(t, timestamps=timestamps),
+    }
+
+
+def analyze_video(
+    url: str,
+    provider: str = "",
+    model: str = "",
+    languages: str = "",
+) -> Dict[str, Any]:
+    """Extract a video's transcript and expose its LOAD-BEARING components:
+    the claims, decisions, tradeoffs, and verdicts the video's conclusion
+    actually rests on (not a generic summary).
+
+    Args:
+        url: YouTube video URL or 11-character video id.
+        provider: LLM provider ("ollama", "openai", "anthropic"). Blank = configured default.
+        model: Model name for the provider. Blank = provider default.
+        languages: Comma-separated language preference. Blank = "en".
+    """
+    if not url or not isinstance(url, str):
+        return {"error": "url must be a non-empty string", "success": False}
+
+    prov, mdl, lang_list = _resolve(provider, model, languages)
+    try:
+        report = analyze(url, provider=prov, model=mdl, languages=lang_list)
+    except Exception as e:
+        logger.warning("analysis failed for %s: %s", url, e)
+        return {"error": str(e), "success": False}
+
+    result = report.to_dict()
+    result["success"] = True
+    result["markdown"] = render_markdown(report)
+    return result
+
+
+def list_analysis_providers() -> Dict[str, Any]:
+    """List the LLM providers available for analysis, which are configured
+    right now, and the models each one can use."""
+    try:
+        providers = discover()
+    except Exception as e:
+        return {"error": str(e), "success": False}
+    return {
+        "success": True,
+        "providers": providers,
+        "default": config.get("analysis", "provider", default="ollama"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool registration dictionary — single source of truth
+# ---------------------------------------------------------------------------
+
+LOADBEARING_YOUTUBE_TOOLS: Dict[str, Dict[str, Any]] = {
+    "analyze_video": {
+        "function": analyze_video,
+        "description": (
+            "Extract a YouTube video's transcript and expose its load-bearing "
+            "components — the claims, decisions, tradeoffs, comparison verdicts, "
+            "and recommendation the conclusion actually rests on, with timestamps. "
+            "Returns structured data plus a rendered markdown report."
+        ),
+    },
+    "get_video_transcript": {
+        "function": get_video_transcript,
+        "description": (
+            "Fetch the full transcript of a YouTube video (no LLM), with optional "
+            "[mm:ss] timestamps, title, author, and duration."
+        ),
+    },
+    "list_analysis_providers": {
+        "function": list_analysis_providers,
+        "description": (
+            "List LLM providers available for analysis, which are configured, and "
+            "the models each can use (Ollama is the local, no-key default)."
+        ),
+    },
+}
+
+
+def get_tools_config() -> Dict[str, Dict[str, Any]]:
+    """Return the tools configuration for bulk registration."""
+    return LOADBEARING_YOUTUBE_TOOLS

--- a/servers/loadbearing-youtube/tests/test_tools.py
+++ b/servers/loadbearing-youtube/tests/test_tools.py
@@ -1,0 +1,45 @@
+"""Tests for the loadbearing_youtube MCP server tool layer.
+
+These cover the adapter's contract (registration, input validation, provider
+discovery passthrough) without hitting the network or an LLM. The analysis
+logic itself is tested in the loadbearing_youtube package.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from tool_config import (  # noqa: E402
+    analyze_video,
+    get_tools_config,
+    get_video_transcript,
+    list_analysis_providers,
+)
+
+
+def test_tools_registered():
+    tools = get_tools_config()
+    assert set(tools) == {"analyze_video", "get_video_transcript", "list_analysis_providers"}
+    for name, spec in tools.items():
+        assert callable(spec["function"])
+        assert spec["description"]
+
+
+def test_analyze_video_rejects_empty_url():
+    result = analyze_video("")
+    assert result["success"] is False
+    assert "error" in result
+
+
+def test_get_video_transcript_rejects_empty_url():
+    result = get_video_transcript("")
+    assert result["success"] is False
+    assert "error" in result
+
+
+def test_list_providers_reports_builtins():
+    result = list_analysis_providers()
+    assert result["success"] is True
+    names = {p["name"] for p in result["providers"]}
+    assert {"ollama", "openai", "anthropic"} <= names

--- a/utils/mcp_manager/pyproject.toml
+++ b/utils/mcp_manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-manager"
-version = "1.3.1"
+version = "1.3.2"
 description = "Comprehensive manager for MCP servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/utils/mcp_manager/src/mcp_manager/__init__.py
+++ b/utils/mcp_manager/src/mcp_manager/__init__.py
@@ -5,4 +5,4 @@ This package provides tools for installing, configuring, and running MCP servers
 with different transport modes (stdio and HTTP+SSE).
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/utils/mcp_manager/src/mcp_manager/core/platforms.py
+++ b/utils/mcp_manager/src/mcp_manager/core/platforms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -44,12 +45,51 @@ def discover_installed_platforms() -> List[PlatformType]:
     return [p for p in PlatformType if is_platform_installed(p)]
 
 
+def _resolve_console_script(server: Server) -> Optional[str]:
+    """Name of the console script that launches this server's MCP entry point.
+
+    mcp-manager's convention is that the script equals the server name, but a
+    server may rename its script (e.g. to avoid colliding with a dependency
+    that ships an identically-named CLI). The authoritative declaration is the
+    `[project.scripts]` table in the server's own pyproject.toml — dependency
+    scripts never appear there. Returns None when it can't be determined, so
+    callers fall back to `server.name` (correct for convention-following
+    servers, and for installs whose source dir is no longer present).
+    """
+    if not server.source_dir:
+        return None
+    pyproject = server.source_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    scripts = data.get("project", {}).get("scripts", {})
+    names = list(scripts)
+    if not names:
+        return None
+    # Convention holds: a script matching the server name is the entry point.
+    if server.name in names:
+        return server.name
+    # Single declared script is unambiguous.
+    if len(names) == 1:
+        return names[0]
+    # Multiple scripts, none matching the name: prefer the MCP-suffixed one.
+    mcp_scripts = [n for n in names if n.endswith("-mcp")]
+    if len(mcp_scripts) == 1:
+        return mcp_scripts[0]
+    return None
+
+
 def _server_executable_path(server: Server) -> Optional[Path]:
     if not server.venv_dir:
         return None
     bin_dir = "Scripts" if sys.platform == "win32" else "bin"
     suffix = ".exe" if sys.platform == "win32" else ""
-    return server.venv_dir / bin_dir / f"{server.name}{suffix}"
+    script_name = _resolve_console_script(server) or server.name
+    return server.venv_dir / bin_dir / f"{script_name}{suffix}"
 
 
 def build_mcp_server_entry(server: Server, platform: PlatformType) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

Adds **loadbearing-youtube** as a new server in `servers/`, alongside `jira-helper`, `worldcontext`, and `mcpservercreator`. It extracts a YouTube transcript and exposes the video's **load-bearing components** — the claims, decisions, tradeoffs, comparison verdicts, and recommendation the conclusion actually rests on (not a generic summary).

The server is a thin [mcp-commons](https://github.com/dawsonlp/mcp-commons) adapter (the "simple approach", same shape as `worldcontext`) over the [`loadbearing_youtube`](https://github.com/dawsonlp/loadbearing_youtube) package, which holds all pipeline/provider/analysis logic.

## Tools

| Tool | Purpose |
|---|---|
| `analyze_video` | Transcript → load-bearing components (structured data + rendered markdown) |
| `get_video_transcript` | Transcript only, no LLM, optional `[mm:ss]` timestamps |
| `list_analysis_providers` | Provider/model discovery |

Ollama is the local, no-key default; OpenAI/Anthropic activate when their keys are set.

## Notes

- Console script is `loadbearing-youtube-mcp` to avoid colliding with the `loadbearing_youtube` package's own `loadbearing-youtube` CLI when both are installed together.
- Depends on `loadbearing_youtube` via a PEP 508 git ref pinned at `v0.1.0`, so `pip`/`uv`/`mcp-manager` resolve it with no auth.
- Listed in the top-level README structure tree and install steps.

## Verification

- 4/4 server tests pass; underlying analysis logic is tested in the `loadbearing_youtube` package.
- Fresh-venv install confirmed to fetch `loadbearing-youtube==0.1.0` from GitHub (not a local path).
- Server entrypoint boots via mcp-commons; verified end-to-end against Ollama (`analyze_video` returns structured analysis + markdown).