### PR TITLE
Install MCP servers into Claude Code, VS Code native MCP, and Codex

### DIFF
--- a/utils/mcp_manager/README.md
+++ b/utils/mcp_manager/README.md
@@ -4,11 +4,11 @@ A comprehensive command-line tool for managing Model Context Protocol (MCP) serv
 
 ## Features
 
-- **Config Status Dashboard** - View comprehensive MCP configuration status across VS Code/Cline and Claude Desktop
+- **Config Status Dashboard** - View comprehensive MCP configuration status across every supported agent
 - Install and manage local MCP servers with isolated environments
 - Configure connections to remote MCP servers
 - Generate wrapper scripts for stdio-based MCP servers
-- Automatically configure VS Code Cline integration
+- **One-command install into multiple AI agents** - Cline, Claude Desktop, Claude Code, VS Code (native MCP), and Codex
 - Support for both stdio and HTTP+SSE transport modes
 - **XDG Compliant** - Centralized management under `~/.config/mcp-manager`
 - **Automatic Migration** - Seamlessly migrates existing configurations
@@ -137,15 +137,19 @@ Per-server `config.yaml` files under `~/.config/mcp-manager/servers/<name>/` (AP
 
 The `--no-pipx` source-copy install flow was removed. Local servers are always installed as isolated packages using `uv`.
 
-## VS Code Cline Integration
+## Supported Agents
 
-MCP Manager automatically configures VS Code Cline integration by updating the settings file at:
+`mcp-manager config sync` pushes the registry into every installed agent it recognizes. Each server is written in the format that agent expects:
 
-```
-~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json
-```
+| Agent | Mechanism | Location |
+|-------|-----------|----------|
+| Cline (VS Code) | JSON file (`mcpServers`) | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Claude Desktop | JSON file (`mcpServers`) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Code | `claude mcp add` CLI (user scope) | `~/.claude.json` |
+| VS Code (native MCP) | JSON file (`servers` + `type`) | `~/Library/Application Support/Code/User/mcp.json` |
+| Codex | `codex mcp add` CLI | `~/.codex/config.toml` |
 
-This allows Cline to connect to your MCP servers directly from VS Code. Use `mcp-manager info system` to verify your configuration status.
+For file-based agents, entries you added by hand are preserved — only servers with a matching name are overwritten, and the file is backed up first. Claude Code and Codex keep MCP servers inside large, live-mutated config files, so mcp-manager delegates to their own `mcp add` / `mcp remove` CLIs rather than rewriting those files directly. Use `mcp-manager info system` to verify configuration status.
 
 ## Commands Reference
 
@@ -160,7 +164,10 @@ This allows Cline to connect to your MCP servers directly from VS Code. Use `mcp
 | `mcp-manager server restart <name>` | Restart a server |
 | `mcp-manager config cline` | Write the registry to VS Code/Cline settings |
 | `mcp-manager config claude` | Write the registry to Claude Desktop settings |
-| `mcp-manager config sync` | Push the registry to all installed AI platforms |
+| `mcp-manager config claude-code` | Register the registry with Claude Code (`claude mcp add`, user scope) |
+| `mcp-manager config vscode` | Write the registry to VS Code native MCP settings (`mcp.json`) |
+| `mcp-manager config codex` | Register the registry with Codex (`codex mcp add`) |
+| `mcp-manager config sync` | Push the registry to all installed AI agents |
 | `mcp-manager config validate` | Validate every server's installation |
 | `mcp-manager remove server <name>` | Remove a server completely from all locations |
 | `mcp-manager remove from-cline <name>` | Remove a server from VS Code/Cline only |

--- a/utils/mcp_manager/pyproject.toml
+++ b/utils/mcp_manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-manager"
-version = "1.3.2"
+version = "1.4.0"
 description = "Comprehensive manager for MCP servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/utils/mcp_manager/src/mcp_manager/__init__.py
+++ b/utils/mcp_manager/src/mcp_manager/__init__.py
@@ -5,4 +5,4 @@ This package provides tools for installing, configuring, and running MCP servers
 with different transport modes (stdio and HTTP+SSE).
 """
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"

--- a/utils/mcp_manager/src/mcp_manager/cli/app.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/app.py
@@ -44,6 +44,9 @@ from mcp_manager.cli.commands.config import (
     backup_config,
     configure_cline,
     configure_claude_desktop,
+    configure_claude_code,
+    configure_codex,
+    configure_vscode,
 )
 from mcp_manager.cli.commands.diagnostics import (
     health_check,
@@ -286,11 +289,31 @@ def configure_claude_wrapper(
     configure_claude_desktop(backup=backup)
 
 
+@config_app.command("claude-code")
+def configure_claude_code_wrapper():
+    """⚙️  Configure Claude Code integration (via `claude mcp add`, user scope)."""
+    configure_claude_code()
+
+
+@config_app.command("codex")
+def configure_codex_wrapper():
+    """⚙️  Configure Codex integration (via `codex mcp add`)."""
+    configure_codex()
+
+
+@config_app.command("vscode")
+def configure_vscode_wrapper(
+    backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
+):
+    """⚙️  Configure VS Code native MCP integration (mcp.json)."""
+    configure_vscode(backup=backup)
+
+
 @config_app.command("sync")
 def sync_wrapper(
     platform: Optional[str] = typer.Option(
         None, "--platform", "-p",
-        help="Specific platform to sync (cline|claude). Default: all installed.",
+        help="Specific platform to sync (cline|claude|claude-code|vscode|codex). Default: all installed.",
     ),
 ):
     """🔄 Push the current server registry into each AI platform's settings."""

--- a/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
@@ -20,6 +20,7 @@ from mcp_manager.core.state import get_state_manager
 from mcp_manager.core.platforms import (
     discover_installed_platforms,
     get_platform_settings_path,
+    is_cli_platform,
     sync_to_platform,
 )
 from mcp_manager.core.validation import validate_server_config
@@ -173,9 +174,13 @@ def validate_config(
 
 _PLATFORM_ALIASES = {
     "cline": PlatformType.CLINE,
-    "vscode": PlatformType.CLINE,
     "claude": PlatformType.CLAUDE_DESKTOP,
     "claude-desktop": PlatformType.CLAUDE_DESKTOP,
+    "claude-code": PlatformType.CLAUDE_CODE,
+    "claudecode": PlatformType.CLAUDE_CODE,
+    "code": PlatformType.VSCODE,
+    "vscode": PlatformType.VSCODE,
+    "codex": PlatformType.CODEX,
 }
 
 
@@ -183,7 +188,7 @@ _PLATFORM_ALIASES = {
 def sync_platforms(
     platform: Optional[str] = typer.Option(
         None, "--platform", "-p",
-        help="Specific platform to sync (cline|claude). Default: all installed.",
+        help="Specific platform to sync (cline|claude|claude-code|vscode|codex). Default: all installed.",
     ),
 ):
     """Push the current server registry into each AI platform's settings.
@@ -460,23 +465,26 @@ def _configure_platform(
     display_name: str,
     restart_hint: str,
 ) -> None:
-    """Shared implementation for `config cline` and `config claude`.
+    """Shared implementation for the per-platform `config <platform>` commands.
 
-    Delegates entry-building + settings-write to `core.platforms.sync_to_platform`
-    (which knows the editor formats for each platform). This function adds the
-    user-facing flow: backup, per-server status output, restart hint.
+    Delegates entry-building + write to `core.platforms.sync_to_platform` (which
+    knows each agent's format and mechanism). This function adds the user-facing
+    flow: backup (file-based agents only), per-server status output, restart hint.
     """
     all_servers = state.get_servers()
     if not all_servers:
         output.warning("No servers found to configure")
         return
 
-    settings_path = get_platform_settings_path(platform)
+    cli_managed = is_cli_platform(platform)
+    settings_path = None
 
-    if backup:
-        backup_path = _backup_settings_file(settings_path)
-        if backup_path is not None:
-            output.info(f"Backed up existing settings to: {backup_path}")
+    if not cli_managed:
+        settings_path = get_platform_settings_path(platform)
+        if backup:
+            backup_path = _backup_settings_file(settings_path)
+            if backup_path is not None:
+                output.info(f"Backed up existing settings to: {backup_path}")
 
     result = sync_to_platform(platform, list(all_servers.values()))
     for name in result["configured"]:
@@ -484,7 +492,10 @@ def _configure_platform(
     for skip in result["skipped"]:
         output.warning(f"Skipped server '{skip['name']}': {skip['reason']}")
 
-    output.success(f"Updated {display_name} settings at: {settings_path}")
+    if settings_path is not None:
+        output.success(f"Updated {display_name} settings at: {settings_path}")
+    else:
+        output.success(f"Registered {len(result['configured'])} server(s) with {display_name}")
     output.info(f"Configured {len(result['configured'])} server(s)")
     output.info(restart_hint)
 
@@ -519,6 +530,50 @@ def configure_claude_desktop(
         )
     except Exception as e:
         handle_error(e, "Failed to configure Claude Desktop")
+
+
+@app.command("claude-code")
+def configure_claude_code():
+    """Configure Claude Code integration (via `claude mcp add`, user scope)."""
+    try:
+        _configure_platform(
+            PlatformType.CLAUDE_CODE,
+            backup=False,
+            display_name="Claude Code",
+            restart_hint="Start a new Claude Code session to pick up the servers.",
+        )
+    except Exception as e:
+        handle_error(e, "Failed to configure Claude Code")
+
+
+@app.command("codex")
+def configure_codex():
+    """Configure Codex integration (via `codex mcp add`)."""
+    try:
+        _configure_platform(
+            PlatformType.CODEX,
+            backup=False,
+            display_name="Codex",
+            restart_hint="Start a new Codex session to pick up the servers.",
+        )
+    except Exception as e:
+        handle_error(e, "Failed to configure Codex")
+
+
+@app.command("vscode")
+def configure_vscode(
+    backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
+):
+    """Configure VS Code native MCP integration (mcp.json)."""
+    try:
+        _configure_platform(
+            PlatformType.VSCODE,
+            backup=backup,
+            display_name="VS Code",
+            restart_hint="Reload the VS Code window for the changes to take effect.",
+        )
+    except Exception as e:
+        handle_error(e, "Failed to configure VS Code")
 
 
 if __name__ == "__main__":

--- a/utils/mcp_manager/src/mcp_manager/core/models.py
+++ b/utils/mcp_manager/src/mcp_manager/core/models.py
@@ -75,6 +75,9 @@ class PlatformType(str, Enum):
     """AI platform types."""
     CLINE = "cline"
     CLAUDE_DESKTOP = "claude_desktop"
+    CLAUDE_CODE = "claude_code"
+    VSCODE = "vscode"
+    CODEX = "codex"
 
 
 class Server(BaseModel):

--- a/utils/mcp_manager/src/mcp_manager/core/platforms.py
+++ b/utils/mcp_manager/src/mcp_manager/core/platforms.py
@@ -1,48 +1,172 @@
 """
 Platform integration for MCP Manager.
 
-Writes the per-editor `mcpServers` settings entries for the local servers
-that mcp-manager owns. Supports VS Code/Cline and Claude Desktop.
+Writes the per-editor MCP settings for the local servers that mcp-manager
+owns. Two mechanisms are supported:
 
-Scope is intentionally narrow: build entries from the current `Server`
-model and push them to the editor's settings file. Reading arbitrary
-external entries back into the registry isn't supported because the
-`Server` model assumes mcp-manager owns the install (venv_dir + source_dir).
+* File-based editors (Cline, Claude Desktop, VS Code native MCP) keep a JSON
+  settings file with a map of server entries. They differ only in the map's
+  top-level key and a few per-entry extras, captured by `_FileProfile`.
+* CLI-managed agents (Claude Code, Codex) keep their MCP servers inside a
+  large, live-mutated config file (`~/.claude.json`, `~/.codex/config.toml`).
+  Rewriting those by hand risks corrupting unrelated state, so we delegate to
+  each agent's own `mcp add` / `mcp remove` CLI instead (`_CliSpec`).
+
+Scope is intentionally narrow: build entries from the current `Server` model
+and push them to the agent. Reading arbitrary external entries back into the
+registry isn't supported because the `Server` model assumes mcp-manager owns
+the install (venv_dir + source_dir).
 """
 
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from mcp_manager.core.logging import MCPManagerLogger
 from mcp_manager.core.models import PlatformType, Server, ServerType, TransportType
 from mcp_manager.core.state import (
     get_claude_desktop_settings_path,
     get_vscode_cline_settings_path,
+    get_vscode_mcp_settings_path,
 )
 
+
+# --------------------------------------------------------------------------
+# Platform profiles
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FileProfile:
+    """How a file-based editor stores its MCP server map.
+
+    container_key: top-level JSON key holding the server map.
+    include_type:  emit an explicit ``"type": "stdio"`` on each entry.
+    cline_extras:  emit Cline's ``disabled`` / ``autoApprove`` fields.
+    """
+
+    container_key: str = "mcpServers"
+    include_type: bool = False
+    cline_extras: bool = False
+
+
+@dataclass(frozen=True)
+class _CliSpec:
+    """How a CLI-managed agent adds/removes an MCP server."""
+
+    binary: str
+    add_argv: Callable[[str, str, List[str], Dict[str, str]], List[str]]
+    remove_argv: Callable[[str], List[str]]
+
+
+_FILE_PROFILES: Dict[PlatformType, _FileProfile] = {
+    PlatformType.CLINE: _FileProfile(cline_extras=True),
+    PlatformType.CLAUDE_DESKTOP: _FileProfile(),
+    PlatformType.VSCODE: _FileProfile(container_key="servers", include_type=True),
+}
 
 _PLATFORM_SETTINGS_PATH_FACTORY = {
     PlatformType.CLINE: get_vscode_cline_settings_path,
     PlatformType.CLAUDE_DESKTOP: get_claude_desktop_settings_path,
+    PlatformType.VSCODE: get_vscode_mcp_settings_path,
 }
 
 
+def _claude_add_argv(name: str, cmd: str, args: List[str], env: Dict[str, str]) -> List[str]:
+    # claude mcp add [-s user] [-e K=V ...] <name> -- <cmd> <args...>
+    argv = ["claude", "mcp", "add", "-s", "user"]
+    for k, v in env.items():
+        argv += ["-e", f"{k}={v}"]
+    argv += [name, "--", cmd, *args]
+    return argv
+
+
+def _claude_remove_argv(name: str) -> List[str]:
+    return ["claude", "mcp", "remove", "-s", "user", name]
+
+
+def _codex_add_argv(name: str, cmd: str, args: List[str], env: Dict[str, str]) -> List[str]:
+    # codex mcp add [--env K=V ...] <name> -- <cmd> <args...>
+    argv = ["codex", "mcp", "add"]
+    for k, v in env.items():
+        argv += ["--env", f"{k}={v}"]
+    argv += [name, "--", cmd, *args]
+    return argv
+
+
+def _codex_remove_argv(name: str) -> List[str]:
+    return ["codex", "mcp", "remove", name]
+
+
+_CLI_SPECS: Dict[PlatformType, _CliSpec] = {
+    PlatformType.CLAUDE_CODE: _CliSpec("claude", _claude_add_argv, _claude_remove_argv),
+    PlatformType.CODEX: _CliSpec("codex", _codex_add_argv, _codex_remove_argv),
+}
+
+
+def is_cli_platform(platform: PlatformType) -> bool:
+    """True if the platform is managed via its own `mcp` CLI, not a JSON file."""
+    return platform in _CLI_SPECS
+
+
+def platform_container_key(platform: PlatformType) -> str:
+    """Top-level JSON key that holds the server map for a file-based platform."""
+    return _FILE_PROFILES[platform].container_key
+
+
+def remove_from_cli_platform(platform: PlatformType, name: str) -> Tuple[bool, str]:
+    """Remove a server from a CLI-managed agent via its own `mcp remove`.
+
+    Returns (success, message). A missing entry is reported as a failure with
+    the CLI's message; callers can treat that as a warning.
+    """
+    spec = _CLI_SPECS[platform]
+    if shutil.which(spec.binary) is None:
+        return False, f"`{spec.binary}` not found on PATH"
+    result = subprocess.run(spec.remove_argv(name), capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        return False, (detail[-1] if detail else "remove failed")
+    return True, "removed"
+
+
+# --------------------------------------------------------------------------
+# Discovery
+# --------------------------------------------------------------------------
+
+
 def get_platform_settings_path(platform: PlatformType) -> Path:
-    return _PLATFORM_SETTINGS_PATH_FACTORY[platform]()
+    factory = _PLATFORM_SETTINGS_PATH_FACTORY.get(platform)
+    if factory is None:
+        raise ValueError(f"{platform.value} has no settings file (CLI-managed)")
+    return factory()
 
 
 def is_platform_installed(platform: PlatformType) -> bool:
-    """Treat a platform as installed if its settings directory exists."""
+    """Whether the agent looks present on this system.
+
+    CLI-managed agents count as installed when their binary is on PATH;
+    file-based editors when their settings directory exists.
+    """
+    if is_cli_platform(platform):
+        return shutil.which(_CLI_SPECS[platform].binary) is not None
     return get_platform_settings_path(platform).parent.exists()
 
 
 def discover_installed_platforms() -> List[PlatformType]:
     return [p for p in PlatformType if is_platform_installed(p)]
+
+
+# --------------------------------------------------------------------------
+# Command resolution
+# --------------------------------------------------------------------------
 
 
 def _resolve_console_script(server: Server) -> Optional[str]:
@@ -92,35 +216,20 @@ def _server_executable_path(server: Server) -> Optional[Path]:
     return server.venv_dir / bin_dir / f"{script_name}{suffix}"
 
 
-def build_mcp_server_entry(server: Server, platform: PlatformType) -> Optional[Dict[str, Any]]:
-    """Build the `mcpServers` JSON entry for one server, or None if it can't be expressed.
+def _resolved_command(server: Server) -> Optional[Tuple[str, List[str]]]:
+    """The (command, args) to launch a syncable local stdio server, or None.
 
-    Cline and Claude Desktop both expect a command/args/env shape; neither
-    supports remote URL entries or SSE transport in their `mcpServers`
-    section. Servers that don't fit are returned as None so callers can
-    skip them with a meaningful reason.
+    Shared by both the file-based entry builder and the CLI adapters so they
+    agree on which servers are expressible and how they're launched.
     """
     if server.server_type != ServerType.LOCAL:
         return None
     if server.transport != TransportType.STDIO:
         return None
-
     executable_path = _server_executable_path(server)
     if not executable_path or not executable_path.exists():
         return None
-
-    entry: Dict[str, Any] = {
-        "command": str(executable_path),
-        "args": ["stdio"],
-    }
-    if server.environment:
-        entry["env"] = dict(server.environment)
-
-    if platform == PlatformType.CLINE:
-        entry["disabled"] = not server.enabled
-        entry["autoApprove"] = list(server.auto_approve)
-
-    return entry
+    return str(executable_path), ["stdio"]
 
 
 def _entry_skip_reason(server: Server) -> str:
@@ -131,6 +240,41 @@ def _entry_skip_reason(server: Server) -> str:
     if not server.venv_dir:
         return "no venv_dir"
     return "executable not found"
+
+
+# --------------------------------------------------------------------------
+# File-based sync
+# --------------------------------------------------------------------------
+
+
+def build_mcp_server_entry(server: Server, platform: PlatformType) -> Optional[Dict[str, Any]]:
+    """Build the settings entry for one server, or None if it can't be expressed.
+
+    Only local stdio servers are expressible; remote/SSE servers return None so
+    callers can skip them with a meaningful reason.
+    """
+    profile = _FILE_PROFILES.get(platform)
+    if profile is None:
+        return None
+
+    resolved = _resolved_command(server)
+    if resolved is None:
+        return None
+    command, args = resolved
+
+    entry: Dict[str, Any] = {}
+    if profile.include_type:
+        entry["type"] = "stdio"
+    entry["command"] = command
+    entry["args"] = args
+    if server.environment:
+        entry["env"] = dict(server.environment)
+
+    if profile.cline_extras:
+        entry["disabled"] = not server.enabled
+        entry["autoApprove"] = list(server.auto_approve)
+
+    return entry
 
 
 def read_platform_settings(platform: PlatformType) -> Dict[str, Any]:
@@ -149,19 +293,14 @@ def write_platform_settings(platform: PlatformType, settings: Dict[str, Any]) ->
     path.write_text(json.dumps(settings, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
-def sync_to_platform(
+def _sync_to_file_platform(
     platform: PlatformType,
     servers: List[Server],
-    logger: Optional[MCPManagerLogger] = None,
+    logger: MCPManagerLogger,
 ) -> Dict[str, List]:
-    """Write our registry's local stdio servers into the editor's settings.
-
-    Preserves any existing `mcpServers` entries the user has added by hand;
-    only entries with matching names are overwritten.
-    """
-    logger = logger or MCPManagerLogger()
+    profile = _FILE_PROFILES[platform]
     settings = read_platform_settings(platform)
-    settings.setdefault("mcpServers", {})
+    container = settings.setdefault(profile.container_key, {})
 
     configured: List[str] = []
     skipped: List[Dict[str, str]] = []
@@ -173,7 +312,7 @@ def sync_to_platform(
             skipped.append({"name": server.name, "reason": reason})
             logger.debug(f"Skipping {server.name} for {platform.value}: {reason}")
             continue
-        settings["mcpServers"][server.name] = entry
+        container[server.name] = entry
         configured.append(server.name)
 
     write_platform_settings(platform, settings)
@@ -181,15 +320,94 @@ def sync_to_platform(
     return {"configured": configured, "skipped": skipped}
 
 
+# --------------------------------------------------------------------------
+# CLI-based sync
+# --------------------------------------------------------------------------
+
+
+def _sync_to_cli_platform(
+    platform: PlatformType,
+    servers: List[Server],
+    logger: MCPManagerLogger,
+) -> Dict[str, List]:
+    spec = _CLI_SPECS[platform]
+    configured: List[str] = []
+    skipped: List[Dict[str, str]] = []
+
+    if shutil.which(spec.binary) is None:
+        for server in servers:
+            skipped.append({"name": server.name, "reason": f"`{spec.binary}` not found on PATH"})
+        return {"configured": configured, "skipped": skipped}
+
+    for server in servers:
+        resolved = _resolved_command(server)
+        if resolved is None:
+            reason = _entry_skip_reason(server)
+            skipped.append({"name": server.name, "reason": reason})
+            logger.debug(f"Skipping {server.name} for {platform.value}: {reason}")
+            continue
+        command, args = resolved
+        env = dict(server.environment or {})
+
+        # Replace any existing entry: remove (ignoring "not found") then add.
+        subprocess.run(spec.remove_argv(server.name), capture_output=True, text=True)
+        result = subprocess.run(
+            spec.add_argv(server.name, command, args, env),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip().splitlines()
+            reason = f"`{spec.binary} mcp add` failed: {detail[-1] if detail else 'unknown error'}"
+            skipped.append({"name": server.name, "reason": reason})
+            logger.debug(f"{spec.binary} mcp add {server.name} failed: {result.stderr}")
+            continue
+        configured.append(server.name)
+
+    logger.info(f"Synced {len(configured)} server(s) to {platform.value}")
+    return {"configured": configured, "skipped": skipped}
+
+
+# --------------------------------------------------------------------------
+# Public sync entry point
+# --------------------------------------------------------------------------
+
+
+def sync_to_platform(
+    platform: PlatformType,
+    servers: List[Server],
+    logger: Optional[MCPManagerLogger] = None,
+) -> Dict[str, List]:
+    """Push the registry's local stdio servers into one agent's config.
+
+    For file-based editors, existing entries the user added by hand are
+    preserved; only entries with a matching name are overwritten. For
+    CLI-managed agents, each server is (re)registered via the agent's own
+    `mcp add` command. Remote servers and non-stdio transports are skipped.
+    """
+    logger = logger or MCPManagerLogger()
+    if is_cli_platform(platform):
+        return _sync_to_cli_platform(platform, servers, logger)
+    return _sync_to_file_platform(platform, servers, logger)
+
+
 def get_platform_status() -> Dict[str, Dict[str, Any]]:
-    """Return status info per platform: installed, settings path, server count."""
+    """Return status info per platform: installed, settings location, count."""
     status: Dict[str, Dict[str, Any]] = {}
     for p in PlatformType:
+        if is_cli_platform(p):
+            status[p.value] = {
+                "installed": is_platform_installed(p),
+                "settings_path": f"(managed by `{_CLI_SPECS[p].binary} mcp`)",
+                "server_count": None,
+            }
+            continue
         path = get_platform_settings_path(p)
         settings = read_platform_settings(p)
+        profile = _FILE_PROFILES[p]
         status[p.value] = {
             "installed": path.parent.exists(),
             "settings_path": str(path),
-            "server_count": len(settings.get("mcpServers", {})),
+            "server_count": len(settings.get(profile.container_key, {})),
         }
     return status

--- a/utils/mcp_manager/src/mcp_manager/core/removal.py
+++ b/utils/mcp_manager/src/mcp_manager/core/removal.py
@@ -21,6 +21,12 @@ from mcp_manager.core.state import (
     get_vscode_cline_settings_path,
     get_claude_desktop_settings_path
 )
+from mcp_manager.core.platforms import (
+    get_platform_settings_path,
+    is_cli_platform,
+    platform_container_key,
+    remove_from_cli_platform,
+)
 from mcp_manager.core.backup import get_backup_manager
 from mcp_manager.core.cleanup import get_cleanup_manager
 
@@ -206,32 +212,43 @@ class RemovalManager:
             RemovalResult with details
         """
         result = RemovalResult(success=True, server_name=name)
-        
-        # Get platform config path
-        if platform == PlatformType.CLINE:
-            config_path = get_vscode_cline_settings_path()
-            platform_name = "cline"
-        elif platform == PlatformType.CLAUDE_DESKTOP:
-            config_path = get_claude_desktop_settings_path()
-            platform_name = "claude"
-        else:
+        platform_name = platform.value
+
+        # CLI-managed agents (Claude Code, Codex): delegate to their own
+        # `mcp remove`; they own their config file, so no backup here.
+        if is_cli_platform(platform):
+            if dry_run:
+                result.add_removal(f"{platform_name} (dry-run)")
+                return result
+            ok, message = remove_from_cli_platform(platform, name)
+            if ok:
+                result.add_removal(platform_name)
+            else:
+                result.add_warning(f"{platform_name}: {message}")
+            return result
+
+        # File-based editors (Cline, Claude Desktop, VS Code native).
+        try:
+            config_path = get_platform_settings_path(platform)
+            container_key = platform_container_key(platform)
+        except (ValueError, KeyError):
             result.add_error(f"Unknown platform: {platform}")
             return result
-        
+
         # Check if config file exists
         if not config_path.exists():
             result.add_warning(f"{platform_name} config file not found")
             return result
-        
+
         try:
             # Read current config
             config = json.loads(config_path.read_text())
-            
+
             # Check if server exists in config
-            if "mcpServers" not in config or name not in config["mcpServers"]:
+            if container_key not in config or name not in config[container_key]:
                 result.add_warning(f"Server '{name}' not found in {platform_name} config")
                 return result
-            
+
             if not dry_run:
                 # Create backup
                 backup_path = self.backup_manager.create_backup(
@@ -239,21 +256,21 @@ class RemovalManager:
                     prefix="before-removal"
                 )
                 result.add_backup(backup_path)
-                
+
                 # Remove server from config
-                del config["mcpServers"][name]
-                
+                del config[container_key][name]
+
                 # Write updated config
                 config_path.write_text(json.dumps(config, indent=2))
                 result.add_removal(platform_name)
             else:
                 result.add_removal(f"{platform_name} (dry-run)")
-        
+
         except json.JSONDecodeError as e:
             result.add_error(f"Invalid JSON in {platform_name} config: {e}")
         except Exception as e:
             result.add_error(f"Failed to remove from {platform_name}: {e}")
-        
+
         return result
     
     def remove_from_registry(

--- a/utils/mcp_manager/src/mcp_manager/core/state.py
+++ b/utils/mcp_manager/src/mcp_manager/core/state.py
@@ -68,13 +68,29 @@ def get_vscode_cline_settings_path() -> Path:
 def get_claude_desktop_settings_path() -> Path:
     """Get the path to the Claude Desktop settings file."""
     import sys
-    
+
     if sys.platform == "darwin":  # macOS
         return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
     elif sys.platform == "win32":  # Windows
         return Path.home() / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
     else:  # Linux and others
         return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def get_vscode_mcp_settings_path() -> Path:
+    """Get the path to VS Code's native MCP settings file (`mcp.json`).
+
+    This is VS Code's own MCP support (Copilot), distinct from the Cline
+    extension. Entries live under a top-level `servers` key.
+    """
+    import sys
+
+    if sys.platform == "darwin":  # macOS
+        return Path.home() / "Library" / "Application Support" / "Code" / "User" / "mcp.json"
+    elif sys.platform == "win32":  # Windows
+        return Path.home() / "AppData" / "Roaming" / "Code" / "User" / "mcp.json"
+    else:  # Linux and others
+        return Path.home() / ".config" / "Code" / "User" / "mcp.json"
 
 
 def create_directory_structure() -> None:


### PR DESCRIPTION
## Summary

Extends `mcp-manager` to install/sync MCP servers into three more agents beyond Cline and Claude Desktop:

- **Claude Code** — via `claude mcp add --scope user` (safe for the large, live-mutated `~/.claude.json`)
- **VS Code native MCP** — `mcp.json` using the `servers` key + `"type": "stdio"` (distinct from the Cline extension)
- **Codex** — via `codex mcp add` (safe for the large `~/.codex/config.toml`)

## Design

The platform layer now covers two mechanisms:

- **File-based with format variants** — `_FileProfile` captures the differences (container key `mcpServers` vs `servers`, explicit `type`, Cline's `disabled`/`autoApprove`). Hand-added entries are preserved and the file is backed up first.
- **CLI-managed agents** — Claude Code and Codex keep MCP servers inside big shared config files, so instead of rewriting them we delegate to each agent's own `mcp add` / `mcp remove` CLI (`_CliSpec`). `discover_installed_platforms` detects these by binary-on-PATH.

`sync_to_platform` dispatches file vs CLI; `remove_from_platform` cleans up the new agents too. New commands: `config claude-code`, `config vscode`, `config codex`. Note: the `vscode` platform alias now points at native VS Code MCP (was Cline; use `cline` for that).

## Validation

`mcp-manager config sync` pushes all 4 registered servers to all 5 agents with no errors. Verified `claude mcp list` (all ✔ Connected) and `codex mcp list`; existing entries preserved (VS Code `github` http, Codex `node_repl` with env, Claude Code HTTP plugins). `loadbearing-youtube` resolves to its `-mcp` console script in every target.

## Not included

**Antigravity** (requested) is deferred: it has no discoverable MCP config yet (no config file, nothing in its `state.vscdb`, no `mcp` key in settings). Wiring it would be guesswork until a server is configured in its UI so the format can be observed.