### PR TITLE
loadbearing-youtube: cloud providers, parallel map, 30k budget

### DIFF
--- a/servers/loadbearing-youtube/config.yaml.example
+++ b/servers/loadbearing-youtube/config.yaml.example
@@ -12,3 +12,10 @@ analysis:
   provider: "ollama"   # ollama | openai | anthropic
   model: ""            # blank = provider default (e.g. llama3.2 for ollama)
   languages: "en"
+
+# Cloud provider API keys. Only needed if analysis.provider is openai/anthropic.
+# These are bridged into the environment at startup. A real environment variable
+# (ANTHROPIC_API_KEY / OPENAI_API_KEY) always takes precedence over these.
+secrets:
+  anthropic_api_key: ""   # sk-ant-...
+  openai_api_key: ""      # sk-...

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.2",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.2",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.4",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/src/tool_config.py
+++ b/servers/loadbearing-youtube/src/tool_config.py
@@ -7,6 +7,7 @@ JSON-serialisable dict; mcp-commons handles the MCP protocol details.
 """
 
 import logging
+import os
 from typing import Any, Dict
 
 from loadbearing_youtube import analyze, get_transcript
@@ -16,6 +17,24 @@ from loadbearing_youtube.render import render_markdown, render_transcript
 from config import config
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_secrets() -> None:
+    """Bridge cloud API keys from the server config.yaml into the environment
+    that loadbearing_youtube's providers read. Keeping keys in config.yaml
+    matches the repo convention (see worldcontext). An already-set env var
+    always wins, so this never clobbers a real environment key."""
+    mapping = {
+        "anthropic_api_key": "ANTHROPIC_API_KEY",
+        "openai_api_key": "OPENAI_API_KEY",
+    }
+    for cfg_key, env_key in mapping.items():
+        value = config.get("secrets", cfg_key, default="") or ""
+        if value and not os.environ.get(env_key):
+            os.environ[env_key] = value
+
+
+_apply_secrets()
 
 
 def _resolve(provider: str, model: str, languages: str) -> tuple:

--- a/servers/loadbearing-youtube/src/tool_config.py
+++ b/servers/loadbearing-youtube/src/tool_config.py
@@ -8,6 +8,10 @@ JSON-serialisable dict; mcp-commons handles the MCP protocol details.
 
 import logging
 import os
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict
 
 from loadbearing_youtube import analyze, get_transcript
@@ -17,6 +21,75 @@ from loadbearing_youtube.render import render_markdown, render_transcript
 from config import config
 
 logger = logging.getLogger(__name__)
+
+# --- async job store --------------------------------------------------------
+# A full analysis of a long video with a cloud model can take ~60-90s, which
+# exceeds a typical MCP client's per-request timeout. So analysis runs on a
+# background thread tracked by job id: analyze_video waits briefly and either
+# returns the finished report or hands back a job_id for get_analysis_result
+# to poll. Jobs live in-process for the server's lifetime.
+
+_JOBS: Dict[str, Dict[str, Any]] = {}
+_EVENTS: Dict[str, threading.Event] = {}
+_JOBS_LOCK = threading.Lock()
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="lb-analysis")
+
+# How long analyze_video blocks before handing back a job_id. Kept under the
+# common ~60s MCP request timeout so short videos return inline in one call.
+_INLINE_WAIT_S = 45
+# Poll wait ceiling for get_analysis_result.
+_MAX_POLL_WAIT_S = 45
+# Drop finished jobs older than this when a new one starts.
+_JOB_TTL_S = 3600
+
+
+def _prune_jobs() -> None:
+    now = time.time()
+    with _JOBS_LOCK:
+        stale = [
+            jid
+            for jid, j in _JOBS.items()
+            if j["status"] in ("done", "error") and now - j.get("finished", now) > _JOB_TTL_S
+        ]
+        for jid in stale:
+            _JOBS.pop(jid, None)
+            _EVENTS.pop(jid, None)
+
+
+def _public_job(job_id: str, job: Dict[str, Any]) -> Dict[str, Any]:
+    """A JSON-serialisable view of a job (never includes threads/events)."""
+    out: Dict[str, Any] = {
+        "success": job["status"] != "error",
+        "job_id": job_id,
+        "status": job["status"],
+        "url": job["url"],
+        "elapsed_seconds": round((job.get("finished") or time.time()) - job["created"], 1),
+    }
+    if job["status"] == "done":
+        out.update(job["result"])
+    elif job["status"] == "error":
+        out["error"] = job["error"]
+    else:
+        out["message"] = (
+            f"Analysis still running. Call get_analysis_result with job_id "
+            f"'{job_id}' to retrieve it."
+        )
+    return out
+
+
+def _run_job(job_id: str, url: str, prov, mdl, lang_list) -> None:
+    try:
+        report = analyze(url, provider=prov, model=mdl, languages=lang_list)
+        result = report.to_dict()
+        result["markdown"] = render_markdown(report)
+        with _JOBS_LOCK:
+            _JOBS[job_id].update(status="done", result=result, finished=time.time())
+    except Exception as e:  # noqa: BLE001 - surface any failure to the caller
+        logger.warning("analysis job %s failed for %s: %s", job_id, url, e)
+        with _JOBS_LOCK:
+            _JOBS[job_id].update(status="error", error=str(e), finished=time.time())
+    finally:
+        _EVENTS[job_id].set()
 
 
 def _apply_secrets() -> None:
@@ -90,6 +163,11 @@ def analyze_video(
     the claims, decisions, tradeoffs, and verdicts the video's conclusion
     actually rests on (not a generic summary).
 
+    Analysis runs on a background job. Short videos finish within a few tens of
+    seconds and are returned inline. If the analysis is still running when the
+    inline wait elapses, this returns status "running" plus a job_id — call
+    get_analysis_result(job_id) to fetch the finished report.
+
     Args:
         url: YouTube video URL or 11-character video id.
         provider: LLM provider ("ollama", "openai", "anthropic"). Blank = configured default.
@@ -99,17 +177,61 @@ def analyze_video(
     if not url or not isinstance(url, str):
         return {"error": "url must be a non-empty string", "success": False}
 
+    _prune_jobs()
     prov, mdl, lang_list = _resolve(provider, model, languages)
-    try:
-        report = analyze(url, provider=prov, model=mdl, languages=lang_list)
-    except Exception as e:
-        logger.warning("analysis failed for %s: %s", url, e)
-        return {"error": str(e), "success": False}
 
-    result = report.to_dict()
-    result["success"] = True
-    result["markdown"] = render_markdown(report)
-    return result
+    job_id = uuid.uuid4().hex[:12]
+    event = threading.Event()
+    with _JOBS_LOCK:
+        _EVENTS[job_id] = event
+        _JOBS[job_id] = {"status": "running", "url": url, "created": time.time()}
+    _EXECUTOR.submit(_run_job, job_id, url, prov, mdl, lang_list)
+
+    event.wait(_INLINE_WAIT_S)
+    with _JOBS_LOCK:
+        return _public_job(job_id, dict(_JOBS[job_id]))
+
+
+def get_analysis_result(job_id: str, wait_seconds: int = 30) -> Dict[str, Any]:
+    """Retrieve (or wait for) the result of an analyze_video job.
+
+    Args:
+        job_id: The id returned by analyze_video when it was still running.
+        wait_seconds: How long to block waiting for completion (0-45). Use 0 for
+            an immediate status check, or a positive value to wait for a
+            still-running job to finish.
+    """
+    if not job_id or not isinstance(job_id, str):
+        return {"error": "job_id must be a non-empty string", "success": False}
+
+    with _JOBS_LOCK:
+        event = _EVENTS.get(job_id)
+        exists = job_id in _JOBS
+    if not exists:
+        return {"error": f"unknown job_id: {job_id}", "success": False}
+
+    wait = max(0, min(int(wait_seconds or 0), _MAX_POLL_WAIT_S))
+    if wait and event is not None:
+        event.wait(wait)
+
+    with _JOBS_LOCK:
+        return _public_job(job_id, dict(_JOBS[job_id]))
+
+
+def list_analysis_jobs() -> Dict[str, Any]:
+    """List analysis jobs tracked by this server (most recent first)."""
+    with _JOBS_LOCK:
+        jobs = [
+            {
+                "job_id": jid,
+                "status": j["status"],
+                "url": j["url"],
+                "elapsed_seconds": round((j.get("finished") or time.time()) - j["created"], 1),
+            }
+            for jid, j in _JOBS.items()
+        ]
+    jobs.sort(key=lambda x: x["elapsed_seconds"])
+    return {"success": True, "jobs": jobs, "count": len(jobs)}
 
 
 def list_analysis_providers() -> Dict[str, Any]:
@@ -137,8 +259,22 @@ LOADBEARING_YOUTUBE_TOOLS: Dict[str, Dict[str, Any]] = {
             "Extract a YouTube video's transcript and expose its load-bearing "
             "components — the claims, decisions, tradeoffs, comparison verdicts, "
             "and recommendation the conclusion actually rests on, with timestamps. "
-            "Returns structured data plus a rendered markdown report."
+            "Returns structured data plus a rendered markdown report. Runs as a "
+            "background job: short videos return inline; if the response has "
+            "status 'running', call get_analysis_result with the returned job_id."
         ),
+    },
+    "get_analysis_result": {
+        "function": get_analysis_result,
+        "description": (
+            "Fetch the result of an analyze_video job by job_id (optionally "
+            "waiting up to 45s for it to finish). Returns status 'running', "
+            "'done' (with the full report), or 'error'."
+        ),
+    },
+    "list_analysis_jobs": {
+        "function": list_analysis_jobs,
+        "description": "List analysis jobs tracked by this server and their status.",
     },
     "get_video_transcript": {
         "function": get_video_transcript,

--- a/servers/loadbearing-youtube/tests/test_tools.py
+++ b/servers/loadbearing-youtube/tests/test_tools.py
@@ -10,17 +10,26 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+import tool_config  # noqa: E402
 from tool_config import (  # noqa: E402
     analyze_video,
+    get_analysis_result,
     get_tools_config,
     get_video_transcript,
+    list_analysis_jobs,
     list_analysis_providers,
 )
 
 
 def test_tools_registered():
     tools = get_tools_config()
-    assert set(tools) == {"analyze_video", "get_video_transcript", "list_analysis_providers"}
+    assert set(tools) == {
+        "analyze_video",
+        "get_analysis_result",
+        "list_analysis_jobs",
+        "get_video_transcript",
+        "list_analysis_providers",
+    }
     for name, spec in tools.items():
         assert callable(spec["function"])
         assert spec["description"]
@@ -30,6 +39,47 @@ def test_analyze_video_rejects_empty_url():
     result = analyze_video("")
     assert result["success"] is False
     assert "error" in result
+
+
+def test_get_analysis_result_unknown_job():
+    result = get_analysis_result("nope")
+    assert result["success"] is False
+    assert "unknown job_id" in result["error"]
+
+
+def test_async_job_lifecycle(monkeypatch):
+    """analyze_video should hand back a job_id while running, and
+    get_analysis_result should return the finished report once done —
+    without any network/LLM (analyze is stubbed)."""
+    import threading
+
+    release = threading.Event()
+
+    class _FakeReport:
+        def to_dict(self):
+            return {"video_id": "vid", "analysis": {"thesis": "T", "components": []}}
+
+    def _fake_analyze(url, provider=None, model=None, languages=None):
+        release.wait(5)  # simulate a slow analysis until the test releases it
+        return _FakeReport()
+
+    monkeypatch.setattr(tool_config, "analyze", _fake_analyze)
+    monkeypatch.setattr(tool_config, "render_markdown", lambda report: "# md")
+    monkeypatch.setattr(tool_config, "_INLINE_WAIT_S", 0)  # force the "running" path
+
+    started = analyze_video("https://youtu.be/abc")
+    assert started["status"] == "running"
+    job_id = started["job_id"]
+
+    release.set()
+    done = get_analysis_result(job_id, wait_seconds=5)
+    assert done["status"] == "done"
+    assert done["success"] is True
+    assert done["video_id"] == "vid"
+    assert done["markdown"] == "# md"
+
+    listed = list_analysis_jobs()
+    assert any(j["job_id"] == job_id for j in listed["jobs"])
 
 
 def test_get_video_transcript_rejects_empty_url():


### PR DESCRIPTION
Follow-on to #23. Enables cloud-model analysis and scales the pipeline for longer videos.

## Changes
- **Cloud providers via config.yaml** (`f46e8af`): pulls `loadbearing-youtube[all]` so the Anthropic/OpenAI SDKs are installed, and bridges `secrets.anthropic_api_key` / `secrets.openai_api_key` from `config.yaml` into the environment the providers read (real env vars still win). Matches the worldcontext convention.
- **Dependency bumps** to `loadbearing_youtube` `v0.1.4` (`c47e4f9`, `ada8968`), which adds:
  - `temperature` fallback for models that deprecate it (e.g. `claude-sonnet-5`)
  - default synthesis budget raised to **30000 tokens**, with truncated-JSON salvage
  - **parallel map stage** (bounded `ThreadPoolExecutor`, `LOADBEARING_MAX_WORKERS=4`); a failed chunk degrades to no candidates
  - streamed Anthropic responses (required once `max_tokens` is large)

## Verified
End-to-end against `claude-sonnet-5` on a 37-min video: parallel map + streaming synthesis at the 30k ceiling, clean parse, 14 components / 4 comparisons, ~70s. `loadbearing_youtube` suite: 24 passing.

## Notes / trade-offs
- Parallelism speeds up the **map** phase only; **synthesis** is inherently serial (needs all candidates) and is now the dominant cost.
- 30k is a *ceiling*, not a target — no cost impact for short analyses, but a verbose model approaching it makes the single synthesis call slow. Streaming keeps it from hitting the SDK's 10-minute non-streaming limit.
- Local Ollama sees little speedup from parallel map (the daemon serializes inference); the win is on cloud providers.