### PR TITLE
Add Antigravity as an MCP sync target

### DIFF
--- a/servers/loadbearing-youtube/config.yaml.example
+++ b/servers/loadbearing-youtube/config.yaml.example
@@ -12,3 +12,10 @@ analysis:
   provider: "ollama"   # ollama | openai | anthropic
   model: ""            # blank = provider default (e.g. llama3.2 for ollama)
   languages: "en"
+
+# Cloud provider API keys. Only needed if analysis.provider is openai/anthropic.
+# These are bridged into the environment at startup. A real environment variable
+# (ANTHROPIC_API_KEY / OPENAI_API_KEY) always takes precedence over these.
+secrets:
+  anthropic_api_key: ""   # sk-ant-...
+  openai_api_key: ""      # sk-...

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.2",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.2",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.4",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "mcp>=1.27.0",
     "mcp-commons>=2.2.2",
     "PyYAML>=6.0.3",
-    "loadbearing-youtube @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
+    "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/servers/loadbearing-youtube/src/tool_config.py
+++ b/servers/loadbearing-youtube/src/tool_config.py
@@ -7,6 +7,7 @@ JSON-serialisable dict; mcp-commons handles the MCP protocol details.
 """
 
 import logging
+import os
 from typing import Any, Dict
 
 from loadbearing_youtube import analyze, get_transcript
@@ -16,6 +17,24 @@ from loadbearing_youtube.render import render_markdown, render_transcript
 from config import config
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_secrets() -> None:
+    """Bridge cloud API keys from the server config.yaml into the environment
+    that loadbearing_youtube's providers read. Keeping keys in config.yaml
+    matches the repo convention (see worldcontext). An already-set env var
+    always wins, so this never clobbers a real environment key."""
+    mapping = {
+        "anthropic_api_key": "ANTHROPIC_API_KEY",
+        "openai_api_key": "OPENAI_API_KEY",
+    }
+    for cfg_key, env_key in mapping.items():
+        value = config.get("secrets", cfg_key, default="") or ""
+        if value and not os.environ.get(env_key):
+            os.environ[env_key] = value
+
+
+_apply_secrets()
 
 
 def _resolve(provider: str, model: str, languages: str) -> tuple:

--- a/servers/loadbearing-youtube/src/tool_config.py
+++ b/servers/loadbearing-youtube/src/tool_config.py
@@ -8,6 +8,10 @@ JSON-serialisable dict; mcp-commons handles the MCP protocol details.
 
 import logging
 import os
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict
 
 from loadbearing_youtube import analyze, get_transcript
@@ -17,6 +21,75 @@ from loadbearing_youtube.render import render_markdown, render_transcript
 from config import config
 
 logger = logging.getLogger(__name__)
+
+# --- async job store --------------------------------------------------------
+# A full analysis of a long video with a cloud model can take ~60-90s, which
+# exceeds a typical MCP client's per-request timeout. So analysis runs on a
+# background thread tracked by job id: analyze_video waits briefly and either
+# returns the finished report or hands back a job_id for get_analysis_result
+# to poll. Jobs live in-process for the server's lifetime.
+
+_JOBS: Dict[str, Dict[str, Any]] = {}
+_EVENTS: Dict[str, threading.Event] = {}
+_JOBS_LOCK = threading.Lock()
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="lb-analysis")
+
+# How long analyze_video blocks before handing back a job_id. Kept under the
+# common ~60s MCP request timeout so short videos return inline in one call.
+_INLINE_WAIT_S = 45
+# Poll wait ceiling for get_analysis_result.
+_MAX_POLL_WAIT_S = 45
+# Drop finished jobs older than this when a new one starts.
+_JOB_TTL_S = 3600
+
+
+def _prune_jobs() -> None:
+    now = time.time()
+    with _JOBS_LOCK:
+        stale = [
+            jid
+            for jid, j in _JOBS.items()
+            if j["status"] in ("done", "error") and now - j.get("finished", now) > _JOB_TTL_S
+        ]
+        for jid in stale:
+            _JOBS.pop(jid, None)
+            _EVENTS.pop(jid, None)
+
+
+def _public_job(job_id: str, job: Dict[str, Any]) -> Dict[str, Any]:
+    """A JSON-serialisable view of a job (never includes threads/events)."""
+    out: Dict[str, Any] = {
+        "success": job["status"] != "error",
+        "job_id": job_id,
+        "status": job["status"],
+        "url": job["url"],
+        "elapsed_seconds": round((job.get("finished") or time.time()) - job["created"], 1),
+    }
+    if job["status"] == "done":
+        out.update(job["result"])
+    elif job["status"] == "error":
+        out["error"] = job["error"]
+    else:
+        out["message"] = (
+            f"Analysis still running. Call get_analysis_result with job_id "
+            f"'{job_id}' to retrieve it."
+        )
+    return out
+
+
+def _run_job(job_id: str, url: str, prov, mdl, lang_list) -> None:
+    try:
+        report = analyze(url, provider=prov, model=mdl, languages=lang_list)
+        result = report.to_dict()
+        result["markdown"] = render_markdown(report)
+        with _JOBS_LOCK:
+            _JOBS[job_id].update(status="done", result=result, finished=time.time())
+    except Exception as e:  # noqa: BLE001 - surface any failure to the caller
+        logger.warning("analysis job %s failed for %s: %s", job_id, url, e)
+        with _JOBS_LOCK:
+            _JOBS[job_id].update(status="error", error=str(e), finished=time.time())
+    finally:
+        _EVENTS[job_id].set()
 
 
 def _apply_secrets() -> None:
@@ -90,6 +163,11 @@ def analyze_video(
     the claims, decisions, tradeoffs, and verdicts the video's conclusion
     actually rests on (not a generic summary).
 
+    Analysis runs on a background job. Short videos finish within a few tens of
+    seconds and are returned inline. If the analysis is still running when the
+    inline wait elapses, this returns status "running" plus a job_id — call
+    get_analysis_result(job_id) to fetch the finished report.
+
     Args:
         url: YouTube video URL or 11-character video id.
         provider: LLM provider ("ollama", "openai", "anthropic"). Blank = configured default.
@@ -99,17 +177,61 @@ def analyze_video(
     if not url or not isinstance(url, str):
         return {"error": "url must be a non-empty string", "success": False}
 
+    _prune_jobs()
     prov, mdl, lang_list = _resolve(provider, model, languages)
-    try:
-        report = analyze(url, provider=prov, model=mdl, languages=lang_list)
-    except Exception as e:
-        logger.warning("analysis failed for %s: %s", url, e)
-        return {"error": str(e), "success": False}
 
-    result = report.to_dict()
-    result["success"] = True
-    result["markdown"] = render_markdown(report)
-    return result
+    job_id = uuid.uuid4().hex[:12]
+    event = threading.Event()
+    with _JOBS_LOCK:
+        _EVENTS[job_id] = event
+        _JOBS[job_id] = {"status": "running", "url": url, "created": time.time()}
+    _EXECUTOR.submit(_run_job, job_id, url, prov, mdl, lang_list)
+
+    event.wait(_INLINE_WAIT_S)
+    with _JOBS_LOCK:
+        return _public_job(job_id, dict(_JOBS[job_id]))
+
+
+def get_analysis_result(job_id: str, wait_seconds: int = 30) -> Dict[str, Any]:
+    """Retrieve (or wait for) the result of an analyze_video job.
+
+    Args:
+        job_id: The id returned by analyze_video when it was still running.
+        wait_seconds: How long to block waiting for completion (0-45). Use 0 for
+            an immediate status check, or a positive value to wait for a
+            still-running job to finish.
+    """
+    if not job_id or not isinstance(job_id, str):
+        return {"error": "job_id must be a non-empty string", "success": False}
+
+    with _JOBS_LOCK:
+        event = _EVENTS.get(job_id)
+        exists = job_id in _JOBS
+    if not exists:
+        return {"error": f"unknown job_id: {job_id}", "success": False}
+
+    wait = max(0, min(int(wait_seconds or 0), _MAX_POLL_WAIT_S))
+    if wait and event is not None:
+        event.wait(wait)
+
+    with _JOBS_LOCK:
+        return _public_job(job_id, dict(_JOBS[job_id]))
+
+
+def list_analysis_jobs() -> Dict[str, Any]:
+    """List analysis jobs tracked by this server (most recent first)."""
+    with _JOBS_LOCK:
+        jobs = [
+            {
+                "job_id": jid,
+                "status": j["status"],
+                "url": j["url"],
+                "elapsed_seconds": round((j.get("finished") or time.time()) - j["created"], 1),
+            }
+            for jid, j in _JOBS.items()
+        ]
+    jobs.sort(key=lambda x: x["elapsed_seconds"])
+    return {"success": True, "jobs": jobs, "count": len(jobs)}
 
 
 def list_analysis_providers() -> Dict[str, Any]:
@@ -137,8 +259,22 @@ LOADBEARING_YOUTUBE_TOOLS: Dict[str, Dict[str, Any]] = {
             "Extract a YouTube video's transcript and expose its load-bearing "
             "components — the claims, decisions, tradeoffs, comparison verdicts, "
             "and recommendation the conclusion actually rests on, with timestamps. "
-            "Returns structured data plus a rendered markdown report."
+            "Returns structured data plus a rendered markdown report. Runs as a "
+            "background job: short videos return inline; if the response has "
+            "status 'running', call get_analysis_result with the returned job_id."
         ),
+    },
+    "get_analysis_result": {
+        "function": get_analysis_result,
+        "description": (
+            "Fetch the result of an analyze_video job by job_id (optionally "
+            "waiting up to 45s for it to finish). Returns status 'running', "
+            "'done' (with the full report), or 'error'."
+        ),
+    },
+    "list_analysis_jobs": {
+        "function": list_analysis_jobs,
+        "description": "List analysis jobs tracked by this server and their status.",
     },
     "get_video_transcript": {
         "function": get_video_transcript,

--- a/servers/loadbearing-youtube/tests/test_tools.py
+++ b/servers/loadbearing-youtube/tests/test_tools.py
@@ -10,17 +10,26 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+import tool_config  # noqa: E402
 from tool_config import (  # noqa: E402
     analyze_video,
+    get_analysis_result,
     get_tools_config,
     get_video_transcript,
+    list_analysis_jobs,
     list_analysis_providers,
 )
 
 
 def test_tools_registered():
     tools = get_tools_config()
-    assert set(tools) == {"analyze_video", "get_video_transcript", "list_analysis_providers"}
+    assert set(tools) == {
+        "analyze_video",
+        "get_analysis_result",
+        "list_analysis_jobs",
+        "get_video_transcript",
+        "list_analysis_providers",
+    }
     for name, spec in tools.items():
         assert callable(spec["function"])
         assert spec["description"]
@@ -30,6 +39,47 @@ def test_analyze_video_rejects_empty_url():
     result = analyze_video("")
     assert result["success"] is False
     assert "error" in result
+
+
+def test_get_analysis_result_unknown_job():
+    result = get_analysis_result("nope")
+    assert result["success"] is False
+    assert "unknown job_id" in result["error"]
+
+
+def test_async_job_lifecycle(monkeypatch):
+    """analyze_video should hand back a job_id while running, and
+    get_analysis_result should return the finished report once done —
+    without any network/LLM (analyze is stubbed)."""
+    import threading
+
+    release = threading.Event()
+
+    class _FakeReport:
+        def to_dict(self):
+            return {"video_id": "vid", "analysis": {"thesis": "T", "components": []}}
+
+    def _fake_analyze(url, provider=None, model=None, languages=None):
+        release.wait(5)  # simulate a slow analysis until the test releases it
+        return _FakeReport()
+
+    monkeypatch.setattr(tool_config, "analyze", _fake_analyze)
+    monkeypatch.setattr(tool_config, "render_markdown", lambda report: "# md")
+    monkeypatch.setattr(tool_config, "_INLINE_WAIT_S", 0)  # force the "running" path
+
+    started = analyze_video("https://youtu.be/abc")
+    assert started["status"] == "running"
+    job_id = started["job_id"]
+
+    release.set()
+    done = get_analysis_result(job_id, wait_seconds=5)
+    assert done["status"] == "done"
+    assert done["success"] is True
+    assert done["video_id"] == "vid"
+    assert done["markdown"] == "# md"
+
+    listed = list_analysis_jobs()
+    assert any(j["job_id"] == job_id for j in listed["jobs"])
 
 
 def test_get_video_transcript_rejects_empty_url():

--- a/utils/mcp_manager/README.md
+++ b/utils/mcp_manager/README.md
@@ -148,6 +148,7 @@ The `--no-pipx` source-copy install flow was removed. Local servers are always i
 | Claude Code | `claude mcp add` CLI (user scope) | `~/.claude.json` |
 | VS Code (native MCP) | JSON file (`servers` + `type`) | `~/Library/Application Support/Code/User/mcp.json` |
 | Codex | `codex mcp add` CLI | `~/.codex/config.toml` |
+| Antigravity | JSON file (`mcpServers`) | `~/.antigravity/mcp_config.json` |
 
 For file-based agents, entries you added by hand are preserved — only servers with a matching name are overwritten, and the file is backed up first. Claude Code and Codex keep MCP servers inside large, live-mutated config files, so mcp-manager delegates to their own `mcp add` / `mcp remove` CLIs rather than rewriting those files directly. Use `mcp-manager info system` to verify configuration status.
 
@@ -167,6 +168,7 @@ For file-based agents, entries you added by hand are preserved — only servers 
 | `mcp-manager config claude-code` | Register the registry with Claude Code (`claude mcp add`, user scope) |
 | `mcp-manager config vscode` | Write the registry to VS Code native MCP settings (`mcp.json`) |
 | `mcp-manager config codex` | Register the registry with Codex (`codex mcp add`) |
+| `mcp-manager config antigravity` | Write the registry to Antigravity (`~/.antigravity/mcp_config.json`) |
 | `mcp-manager config sync` | Push the registry to all installed AI agents |
 | `mcp-manager config validate` | Validate every server's installation |
 | `mcp-manager remove server <name>` | Remove a server completely from all locations |

--- a/utils/mcp_manager/pyproject.toml
+++ b/utils/mcp_manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-manager"
-version = "1.4.0"
+version = "1.4.1"
 description = "Comprehensive manager for MCP servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/utils/mcp_manager/src/mcp_manager/__init__.py
+++ b/utils/mcp_manager/src/mcp_manager/__init__.py
@@ -5,4 +5,4 @@ This package provides tools for installing, configuring, and running MCP servers
 with different transport modes (stdio and HTTP+SSE).
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/utils/mcp_manager/src/mcp_manager/cli/app.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/app.py
@@ -47,6 +47,7 @@ from mcp_manager.cli.commands.config import (
     configure_claude_code,
     configure_codex,
     configure_vscode,
+    configure_antigravity,
 )
 from mcp_manager.cli.commands.diagnostics import (
     health_check,
@@ -309,11 +310,19 @@ def configure_vscode_wrapper(
     configure_vscode(backup=backup)
 
 
+@config_app.command("antigravity")
+def configure_antigravity_wrapper(
+    backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
+):
+    """⚙️  Configure Antigravity integration (~/.antigravity/mcp_config.json)."""
+    configure_antigravity(backup=backup)
+
+
 @config_app.command("sync")
 def sync_wrapper(
     platform: Optional[str] = typer.Option(
         None, "--platform", "-p",
-        help="Specific platform to sync (cline|claude|claude-code|vscode|codex). Default: all installed.",
+        help="Specific platform to sync (cline|claude|claude-code|vscode|codex|antigravity). Default: all installed.",
     ),
 ):
     """🔄 Push the current server registry into each AI platform's settings."""

--- a/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
@@ -181,6 +181,8 @@ _PLATFORM_ALIASES = {
     "code": PlatformType.VSCODE,
     "vscode": PlatformType.VSCODE,
     "codex": PlatformType.CODEX,
+    "antigravity": PlatformType.ANTIGRAVITY,
+    "agy": PlatformType.ANTIGRAVITY,
 }
 
 
@@ -188,7 +190,7 @@ _PLATFORM_ALIASES = {
 def sync_platforms(
     platform: Optional[str] = typer.Option(
         None, "--platform", "-p",
-        help="Specific platform to sync (cline|claude|claude-code|vscode|codex). Default: all installed.",
+        help="Specific platform to sync (cline|claude|claude-code|vscode|codex|antigravity). Default: all installed.",
     ),
 ):
     """Push the current server registry into each AI platform's settings.
@@ -574,6 +576,22 @@ def configure_vscode(
         )
     except Exception as e:
         handle_error(e, "Failed to configure VS Code")
+
+
+@app.command("antigravity")
+def configure_antigravity(
+    backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
+):
+    """Configure Antigravity integration (~/.antigravity/mcp_config.json)."""
+    try:
+        _configure_platform(
+            PlatformType.ANTIGRAVITY,
+            backup=backup,
+            display_name="Antigravity",
+            restart_hint="Restart Antigravity, then check its MCP/plugins panel to confirm the servers appear.",
+        )
+    except Exception as e:
+        handle_error(e, "Failed to configure Antigravity")
 
 
 if __name__ == "__main__":

--- a/utils/mcp_manager/src/mcp_manager/core/models.py
+++ b/utils/mcp_manager/src/mcp_manager/core/models.py
@@ -78,6 +78,7 @@ class PlatformType(str, Enum):
     CLAUDE_CODE = "claude_code"
     VSCODE = "vscode"
     CODEX = "codex"
+    ANTIGRAVITY = "antigravity"
 
 
 class Server(BaseModel):

--- a/utils/mcp_manager/src/mcp_manager/core/platforms.py
+++ b/utils/mcp_manager/src/mcp_manager/core/platforms.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from mcp_manager.core.logging import MCPManagerLogger
 from mcp_manager.core.models import PlatformType, Server, ServerType, TransportType
 from mcp_manager.core.state import (
+    get_antigravity_mcp_settings_path,
     get_claude_desktop_settings_path,
     get_vscode_cline_settings_path,
     get_vscode_mcp_settings_path,
@@ -70,12 +71,14 @@ _FILE_PROFILES: Dict[PlatformType, _FileProfile] = {
     PlatformType.CLINE: _FileProfile(cline_extras=True),
     PlatformType.CLAUDE_DESKTOP: _FileProfile(),
     PlatformType.VSCODE: _FileProfile(container_key="servers", include_type=True),
+    PlatformType.ANTIGRAVITY: _FileProfile(),
 }
 
 _PLATFORM_SETTINGS_PATH_FACTORY = {
     PlatformType.CLINE: get_vscode_cline_settings_path,
     PlatformType.CLAUDE_DESKTOP: get_claude_desktop_settings_path,
     PlatformType.VSCODE: get_vscode_mcp_settings_path,
+    PlatformType.ANTIGRAVITY: get_antigravity_mcp_settings_path,
 }
 
 

--- a/utils/mcp_manager/src/mcp_manager/core/state.py
+++ b/utils/mcp_manager/src/mcp_manager/core/state.py
@@ -93,6 +93,18 @@ def get_vscode_mcp_settings_path() -> Path:
         return Path.home() / ".config" / "Code" / "User" / "mcp.json"
 
 
+def get_antigravity_mcp_settings_path() -> Path:
+    """Get the path to Antigravity's MCP config file (`mcp_config.json`).
+
+    Antigravity (Google) is a VS Code fork of Codeium/Windsurf lineage. It keeps
+    its data under `~/.antigravity/` (distinct from Windsurf's `~/.codeium/`) and
+    reads MCP servers from `mcp_config.json` there, using the Codeium
+    `mcpServers` format (command/args/env). The path is consistent across
+    platforms because it is home-relative, not an OS app-data dir.
+    """
+    return Path.home() / ".antigravity" / "mcp_config.json"
+
+
 def create_directory_structure() -> None:
     """Create the MCP directory structure if it doesn't exist."""
     # Create main directories


### PR DESCRIPTION
## Summary

Completes the multi-agent work (#25) by adding **Antigravity** (Google) as a sync target.

Antigravity is a VS Code fork of Codeium/Windsurf lineage. I reverse-engineered its config surface from the bundled `Resources/bin/language_server` binary and its on-disk data home:

- **Filename**: `mcp_config.json` (string-confirmed in the binary)
- **Top-level key**: `mcpServers` (confirmed in the binary and in the real `~/.codeium/mcp_config.json` Codeium-family file)
- **Entry shape**: standard `command` / `args` / `env` — identical to Cline/Claude Desktop, so it reuses the file-based sync path with a default `_FileProfile`

## Path

`~/.antigravity/mcp_config.json` — Antigravity's own data home (holds `extensions/`, `argv.json`), distinct from Windsurf's `~/.codeium/`. A new Google product with its own home dir won't write into Codeium's.

**This path is inferred, not officially confirmed.** Antigravity had never loaded MCP on this machine (no config file, empty `state.vscdb`, no logs), so it couldn't be observed directly. If Antigravity actually reads a different location, the written file is inert (non-destructive) and only `get_antigravity_mcp_settings_path()` needs to change.

## Validation

`config antigravity` writes the 4 registered servers to `~/.antigravity/mcp_config.json` in the correct format (`loadbearing-youtube` → `-mcp`). `discover_installed_platforms()` now returns all six agents; `config sync` covers them in one command. Confirmation that Antigravity *reads* it requires opening the app's MCP panel.