### PR TITLE
Fix Antigravity MCP config path (~/.gemini/config/mcp_config.json)

### DIFF
--- a/utils/mcp_manager/README.md
+++ b/utils/mcp_manager/README.md
@@ -148,7 +148,7 @@ The `--no-pipx` source-copy install flow was removed. Local servers are always i
 | Claude Code | `claude mcp add` CLI (user scope) | `~/.claude.json` |
 | VS Code (native MCP) | JSON file (`servers` + `type`) | `~/Library/Application Support/Code/User/mcp.json` |
 | Codex | `codex mcp add` CLI | `~/.codex/config.toml` |
-| Antigravity | JSON file (`mcpServers`) | `~/.antigravity/mcp_config.json` |
+| Antigravity | JSON file (`mcpServers`) | `~/.gemini/config/mcp_config.json` |
 
 For file-based agents, entries you added by hand are preserved — only servers with a matching name are overwritten, and the file is backed up first. Claude Code and Codex keep MCP servers inside large, live-mutated config files, so mcp-manager delegates to their own `mcp add` / `mcp remove` CLIs rather than rewriting those files directly. Use `mcp-manager info system` to verify configuration status.
 

--- a/utils/mcp_manager/pyproject.toml
+++ b/utils/mcp_manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-manager"
-version = "1.4.1"
+version = "1.4.2"
 description = "Comprehensive manager for MCP servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/utils/mcp_manager/src/mcp_manager/__init__.py
+++ b/utils/mcp_manager/src/mcp_manager/__init__.py
@@ -5,4 +5,4 @@ This package provides tools for installing, configuring, and running MCP servers
 with different transport modes (stdio and HTTP+SSE).
 """
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/utils/mcp_manager/src/mcp_manager/cli/app.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/app.py
@@ -314,7 +314,7 @@ def configure_vscode_wrapper(
 def configure_antigravity_wrapper(
     backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
 ):
-    """⚙️  Configure Antigravity integration (~/.antigravity/mcp_config.json)."""
+    """⚙️  Configure Antigravity integration (~/.gemini/config/mcp_config.json)."""
     configure_antigravity(backup=backup)
 
 

--- a/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
+++ b/utils/mcp_manager/src/mcp_manager/cli/commands/config.py
@@ -582,7 +582,7 @@ def configure_vscode(
 def configure_antigravity(
     backup: bool = typer.Option(True, "--backup/--no-backup", help="Create backup before updating"),
 ):
-    """Configure Antigravity integration (~/.antigravity/mcp_config.json)."""
+    """Configure Antigravity integration (~/.gemini/config/mcp_config.json)."""
     try:
         _configure_platform(
             PlatformType.ANTIGRAVITY,

--- a/utils/mcp_manager/src/mcp_manager/core/state.py
+++ b/utils/mcp_manager/src/mcp_manager/core/state.py
@@ -96,13 +96,13 @@ def get_vscode_mcp_settings_path() -> Path:
 def get_antigravity_mcp_settings_path() -> Path:
     """Get the path to Antigravity's MCP config file (`mcp_config.json`).
 
-    Antigravity (Google) is a VS Code fork of Codeium/Windsurf lineage. It keeps
-    its data under `~/.antigravity/` (distinct from Windsurf's `~/.codeium/`) and
-    reads MCP servers from `mcp_config.json` there, using the Codeium
-    `mcpServers` format (command/args/env). The path is consistent across
-    platforms because it is home-relative, not an OS app-data dir.
+    Antigravity (Google) reads local stdio MCP servers from its Gemini config
+    home, using the standard `mcpServers` format (command/args/env). The path is
+    home-relative (not an OS app-data dir), so it is the same on every platform.
+    (Note: `~/.antigravity/` holds Antigravity's VS Code extension data, not the
+    MCP config — the config lives under `~/.gemini/config/`.)
     """
-    return Path.home() / ".antigravity" / "mcp_config.json"
+    return Path.home() / ".gemini" / "config" / "mcp_config.json"
 
 
 def create_directory_structure() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #27. The inferred Antigravity path was wrong.

Confirmed against a live Antigravity install: it reads local stdio MCP servers from **`~/.gemini/config/mcp_config.json`**, not `~/.antigravity/mcp_config.json` (that dir holds Antigravity's VS Code *extension* data — a red herring).

The format was already correct (standard `mcpServers` with `command`/`args`/`env`), so this is a one-line change to `get_antigravity_mcp_settings_path()` plus doc/help updates.

## Validation

`config antigravity` now writes all 4 registered servers to `~/.gemini/config/mcp_config.json` in the correct format (`loadbearing-youtube` → `-mcp`), backing up the prior file first. Verified content on disk.