### PR TITLE
chore(mcp-manager): bump to 1.5.0

### DIFF
--- a/utils/mcp_manager/pyproject.toml
+++ b/utils/mcp_manager/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-manager"
-version = "1.4.2"
+version = "1.5.0"
 description = "Comprehensive manager for MCP servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/utils/mcp_manager/src/mcp_manager/__init__.py
+++ b/utils/mcp_manager/src/mcp_manager/__init__.py
@@ -5,4 +5,4 @@ This package provides tools for installing, configuring, and running MCP servers
 with different transport modes (stdio and HTTP+SSE).
 """
 
-__version__ = "1.4.2"
+__version__ = "1.5.0"


### PR DESCRIPTION
Version bump reflecting the CLI simplification (flat 7-command surface) and dead-code removal (process/health/admin/remote/backup subsystems removed; package ~9,750 → ~4,000 LOC across #29 and #30).