### PR TITLE
build(servers): upgrade mcp-commons to v3

### DIFF
--- a/servers/jira-helper/pyproject.toml
+++ b/servers/jira-helper/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     # Core MCP
     "mcp>=1.27.0",
-    "mcp-commons>=2.2.2",
+    "mcp-commons>=3.0.0,<4",
     
     # Jira/Confluence integration 
     "atlassian-python-api>=4.0.7",

--- a/servers/loadbearing-youtube/pyproject.toml
+++ b/servers/loadbearing-youtube/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.11"
 
 dependencies = [
     "mcp>=1.27.0",
-    "mcp-commons>=2.2.2",
+    "mcp-commons>=3.0.0,<4",
     "PyYAML>=6.0.3",
     "loadbearing-youtube[all] @ git+https://github.com/dawsonlp/loadbearing_youtube@v0.1.4",
 ]

--- a/servers/mcpservercreator/pyproject.toml
+++ b/servers/mcpservercreator/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
     "mcp>=1.27.0",
-    "mcp-commons>=2.2.2",
+    "mcp-commons>=3.0.0,<4",
     "rich>=14.3.3",
     "pydantic-settings>=2.13.1",
     "python-decouple>=3.8",

--- a/servers/template/pyproject.toml
+++ b/servers/template/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
     "mcp>=1.27.0",
-    "mcp-commons>=2.2.2",
+    "mcp-commons>=3.0.0,<4",
     "PyYAML>=6.0.3",
 ]
 

--- a/servers/worldcontext/pyproject.toml
+++ b/servers/worldcontext/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.11"
 
 dependencies = [
     "mcp>=1.27.0",
-    "mcp-commons>=2.2.2",
+    "mcp-commons>=3.0.0,<4",
     "httpx>=0.28.1",
     "PyYAML>=6.0.3",
 ]


### PR DESCRIPTION
Bumps all five servers to `mcp-commons>=3.0.0,<4`. v3's breaking changes (UseCaseResult rename, dropped `config=` param, run_mcp_server logging) don't affect these servers — none use UseCaseResult, none pass `config=`, and all enter via `run_cli` (which still configures logging). Verified worldcontext + jira-helper build against mcp-commons 3.0.0 and run.